### PR TITLE
Script fix - point to master

### DIFF
--- a/setupRemhos.sh
+++ b/setupRemhos.sh
@@ -1,4 +1,4 @@
-git checkout use-mfem-master && cd ../ &&
+cd ../ &&
 wget https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/download/hypre-2.10.0b.tar.gz &&
 tar -zxvf hypre-2.10.0b.tar.gz &&
 mv hypre-2.10.0b hypre &&


### PR DESCRIPTION
Since the MFEM-4.0 branch got merged (PR #3), we can update the script to point to master. 