### PR TITLE
Change bdr

### DIFF
--- a/remhos.cpp
+++ b/remhos.cpp
@@ -657,7 +657,6 @@ public:
       {
          for (k = 0; k < ne; k++)
          {
-
             if (dim==1)      { mesh->GetElementVertices(k, bdrs); }
             else if (dim==2) { mesh->GetElementEdges(k, bdrs, orientation); }
             else if (dim==3) { mesh->GetElementFaces(k, bdrs, orientation); }


### PR DESCRIPTION
I am using "LinearFluxLumping" to incorporate flux terms, in all schemes, even in the case without monotonicity treatment. This means, that the use of Bernstein basis is an essential requirement, and that the basic discrete upwinding method has changed. 

These changes fix the bugs in the corresponding low order scheme, and work fine in serial and parallel.