### PR TITLE
Enable PA and next gen FA 

### DIFF
--- a/remhos.cpp
+++ b/remhos.cpp
@@ -132,6 +132,7 @@ int main(int argc, char *argv[])
    FCTSolverType fct_type         = FCTSolverType::None;
    MonolithicSolverType mono_type = MonolithicSolverType::None;
    bool pa = false;
+   bool next_gen_full = false;
    int smth_ind_type = 0;
    double t_final = 4.0;
    double dt = 0.005;
@@ -184,6 +185,9 @@ int main(int argc, char *argv[])
    args.AddOption(&pa, "-pa", "--partial-assembly", "-no-pa",
                   "--no-partial-assembly",
                   "Enable or disable partial assembly for the HO solution.");
+   args.AddOption(&next_gen_full, "-full", "--next-gen-full", "-no-full",
+                  "--no-next-gen-full",
+                  "Enable or disable next gen full assembly for the HO solution.");
    args.AddOption(&device_config, "-d", "--device",
                   "Device configuration string, see Device::Configure().");
    args.AddOption(&smth_ind_type, "-si", "--smth_ind",
@@ -413,7 +417,8 @@ int main(int argc, char *argv[])
       M_HO.SetAssemblyLevel(AssemblyLevel::PARTIAL);
       K_HO.SetAssemblyLevel(AssemblyLevel::PARTIAL);
    }
-   else if (dim > 1)
+
+   if (next_gen_full)
    {
       K_HO.SetAssemblyLevel(AssemblyLevel::FULL);
    }

--- a/remhos_fct.cpp
+++ b/remhos_fct.cpp
@@ -198,7 +198,7 @@ void FluxBasedFCT::CalcFCTProduct(const ParGridFunction &us, const Vector &m,
 #ifdef REMHOS_FCT_DEBUG
       // Check the LO product solution.
       for (int j = 0; j < ndofs; j++)
-      {         
+      {
          dof_id = k*ndofs + j;
          if (active_dofs[dof_id] == false) { continue; }
 
@@ -281,9 +281,10 @@ void FluxBasedFCT::ComputeFluxMatrix(const ParGridFunction &u,
                                      SparseMatrix &flux_mat) const
 {
    const int s = u.Size();
-   double *flux_data = flux_mat.GetData();
-   const int *K_I = K.GetI(), *K_J = K.GetJ();
-   const double *K_data = K.GetData();
+   double *flux_data = flux_mat.HostReadWriteData();
+   flux_mat.HostReadI(); flux_mat.HostReadJ();
+   const int *K_I = K.HostReadI(), *K_J = K.HostReadJ();
+   const double *K_data = K.HostReadData();
    const double *u_np = u.FaceNbrData().HostRead();
    u.HostRead();
    du_ho.HostRead();
@@ -387,7 +388,7 @@ UpdateSolutionAndFlux(const Vector &du_lo, const Vector &m,
                       SparseMatrix &flux_mat, Vector &du) const
 {
    Vector &a_pos_n = coeff_pos.FaceNbrData(),
-          &a_neg_n = coeff_neg.FaceNbrData();
+           &a_neg_n = coeff_neg.FaceNbrData();
    coeff_pos.ExchangeFaceNbrData();
    coeff_neg.ExchangeFaceNbrData();
 
@@ -397,8 +398,8 @@ UpdateSolutionAndFlux(const Vector &du_lo, const Vector &m,
    coeff_neg.HostReadWrite();
    du.HostReadWrite();
 
-   double *flux_data = flux_mat.GetData();
-   const int *flux_I = flux_mat.GetI(), *flux_J = flux_mat.GetJ();
+   double *flux_data = flux_mat.HostReadWriteData();
+   const int *flux_I = flux_mat.HostReadI(), *flux_J = flux_mat.HostReadJ();
    const int s = du.Size();
    for (int i = 0; i < s; i++)
    {

--- a/remhos_fct.hpp
+++ b/remhos_fct.hpp
@@ -80,11 +80,11 @@ protected:
    void AddFluxesAtDofs(const SparseMatrix &flux_mat,
                         Vector &flux_pos, Vector &flux_neg) const;
    void ComputeFluxCoefficients(const Vector &u, const Vector &du_lo,
-      const Vector &m, const Vector &u_min, const Vector &u_max,
-      Vector &coeff_pos, Vector &coeff_neg) const;
+                                const Vector &m, const Vector &u_min, const Vector &u_max,
+                                Vector &coeff_pos, Vector &coeff_neg) const;
    void UpdateSolutionAndFlux(const Vector &du_lo, const Vector &m,
-      ParGridFunction &coeff_pos, ParGridFunction &coeff_neg,
-      SparseMatrix &flux_mat, Vector &du) const;
+                              ParGridFunction &coeff_pos, ParGridFunction &coeff_neg,
+                              SparseMatrix &flux_mat, Vector &du) const;
 
 public:
    FluxBasedFCT(ParFiniteElementSpace &space,

--- a/remhos_ho.cpp
+++ b/remhos_ho.cpp
@@ -39,8 +39,6 @@ void CGHOSolver::CalcHOSolution(const Vector &u, Vector &du) const
    Array<int> ess_tdof_list;
    if (M.GetAssemblyLevel() == AssemblyLevel::PARTIAL)
    {
-      MFEM_ABORT("PA for DG is not yet implemented.");
-
       K.Mult(u, rhs);
 
       M_solver.SetOperator(M);
@@ -48,7 +46,10 @@ void CGHOSolver::CalcHOSolution(const Vector &u, Vector &du) const
    }
    else
    {
-      K_mat = K.ParallelAssemble();
+      K.SpMat().HostReadWriteI();
+      K.SpMat().HostReadWriteJ();
+      K.SpMat().HostReadData();
+      K_mat = K.ParallelAssemble(&K.SpMat());
       K_mat->Mult(u, rhs);
 
       M_mat = M.ParallelAssemble();
@@ -80,12 +81,14 @@ void LocalInverseHOSolver::CalcHOSolution(const Vector &u, Vector &du) const
    HypreParMatrix *K_mat = NULL;
    if (M.GetAssemblyLevel() == AssemblyLevel::PARTIAL)
    {
-      MFEM_ABORT("PA for DG is not yet implemented.");
       K.Mult(u, rhs);
    }
    else
    {
-      K_mat = K.ParallelAssemble();
+      K.SpMat().HostReadWriteI();
+      K.SpMat().HostReadWriteJ();
+      K.SpMat().HostReadWriteData();
+      K_mat = K.ParallelAssemble(&K.SpMat());
       K_mat->Mult(u, rhs);
    }
 

--- a/remhos_mono.cpp
+++ b/remhos_mono.cpp
@@ -94,7 +94,7 @@ void MonoRDSolver::CalcSolution(const Vector &u, Vector &du) const
       }
    }
    assembly.dofs.ComputeElementsMinMax(u, assembly.dofs.xe_min,
-                                          assembly.dofs.xe_max, NULL, NULL);
+                                       assembly.dofs.xe_max, NULL, NULL);
    assembly.dofs.ComputeBounds(assembly.dofs.xe_min, assembly.dofs.xe_max,
                                assembly.dofs.xi_min, assembly.dofs.xi_max);
 

--- a/remhos_tools.cpp
+++ b/remhos_tools.cpp
@@ -399,7 +399,7 @@ void DofInfo::ComputeBounds(const Vector &el_min, const Vector &el_max,
       }
    }
    Array<double> minvals(x_min.GetData(), x_min.Size()),
-                 maxvals(x_max.GetData(), x_max.Size());
+         maxvals(x_max.GetData(), x_max.Size());
    gcomm.Reduce<double>(minvals, GroupCommunicator::Min);
    gcomm.Bcast(minvals);
    gcomm.Reduce<double>(maxvals, GroupCommunicator::Max);


### PR DESCRIPTION
This PR builds on the MFEM branch: https://github.com/mfem/mfem/pull/1732 (Please note its still WIP). 
Here I am just logging what I see when trying out the branch. 

Atomics could lead to different results when using the GPU, I just want to understand a bit what could lead to differences before we integrate the new capabilities. 

Using autotest I see **no** differences when running on the CPU. 

The CUDA version of autotest reports differences with the following problems

Here I used the command ./test.sh 2 cuda 

last tested with MFEM hash: 63953f55ff4bfb5fb7b432ecdf30a6e3d0e54c96

-- Remap pacman nonper-struct-2D                                                                                                                                                                                             
! lrun -n 2 ./remhos -no-vis --verify-bounds -d cuda -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 3 -lo 1 -fct 1                                                                                            
! Final mass u:  0.08773095629                                                                                                              
! Max value u:   0.9112464601 

[Expected]
  Final mass u:  0.08479546829                                                                                                                                                                                                
! Max value u:   0.9055102425   

-- Remap bump nonper-struct-3D                                                                                                                                                                                               
! lrun -n 2 ./remhos -no-vis --verify-bounds -d cuda -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 3 -lo 1 -fct 1                                                                                           
! Final mass u:  0.1200095515                                                                                                               
! Max value u:   0.9961733167  

[Expected]
! Final mass u:  0.11972981                                                                                                                                                                                                   
! Max value u:   0.996173945   


 --- Steady monolithic 2 2D                                                                                                                                                                                                  
! lrun -n 2 ./remhos -no-vis --verify-bounds -d cuda -m ./data/inline-quad.mesh -p 7 -rs 3 -o 1 -dt 0.01 -tf 20 -mono 1 -si 2                                                                                                 
! Final mass u:  0.1570822864                                                                                                               
! Max value u:   0.9979159883  

[Expected]
! Final mass u:  0.1570667907                                                                                                                                                                                                 
! Max value u:   0.9987771164   

--- Steady monolithic 1 2D                                                                                                                                                                                                  
! lrun -n 2 ./remhos -no-vis --verify-bounds -d cuda -m ./data/inline-quad.mesh -p 6 -rs 2 -o 1 -dt 0.01 -tf 20 -mono 1 -si 1                                                                                                 
! Final mass u:  0.3015484038                                                                                                                                                                                                 
  Max value u:   1  

[Expected]
! Final mass u:  0.3182739921                                                                                                                                                                                                 
  Max value u:   1        