### PR TITLE
Use shared actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: build Hypre
       if: steps.hypre-cache.outputs.cache-hit != 'true'
-      uses: mfem/mfem-actions/build-hypre@master
+      uses: mfem/github-actions/build-hypre@master
       with:
         hypre-archive: ${{ env.HYPRE_ARCHIVE }}
         hypre-dir: ${{ env.HYPRE_TOP_DIR }}
@@ -58,7 +58,7 @@ jobs:
 
     - name: build metis
       if: steps.metis-cache.outputs.cache-hit != 'true'
-      uses: mfem/mfem-actions/build-metis@master
+      uses: mfem/github-actions/build-metis@master
       with:
         metis-archive: ${{ env.METIS_ARCHIVE }}
         metis-dir: ${{ env.METIS_TOP_DIR }}
@@ -87,7 +87,7 @@ jobs:
 
     - name: build mfem
       if: steps.mfem-cache.outputs.cache-hit != 'true'
-      uses: mfem/mfem-actions/build-mfem@master
+      uses: mfem/github-actions/build-mfem@master
       with:
         os: ${{ runner.os }}
         hypre-dir: ${{ env.HYPRE_TOP_DIR }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,6 +63,15 @@ jobs:
         metis-archive: ${{ env.METIS_ARCHIVE }}
         metis-dir: ${{ env.METIS_TOP_DIR }}
 
+    # make generic links to libraries for MFEM install
+    # Those links are already created by build-mfem action, but not when the cache is used...
+    - name: configure links
+      run: |
+        echo "Hypre symlink:"
+        ln -s $HYPRE_TOP_DIR hypre;
+        echo "Metis symlink:"
+        ln -s $METIS_TOP_DIR metis-4.0;
+
     - name: MFEM ${{ env.MFEM_BRANCH }} commit
       run: |
         echo "MFEM_COMMIT=$(git ls-remote --heads https://github.com/mfem/mfem.git ${{ env.MFEM_BRANCH }} | awk '{print $1;}')" >> $GITHUB_ENV

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 env:
   HYPRE_URL: https://github.com/hypre-space/hypre/archive
@@ -15,7 +13,6 @@ env:
   METIS_URL: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD
   METIS_ARCHIVE: metis-4.0.3.tar.gz
   METIS_TOP_DIR: metis-4.0.3
-  MFEM_REPO: https://github.com/mfem/mfem.git
   MFEM_BRANCH: master
   MFEM_TOP_DIR: mfem
 
@@ -36,67 +33,60 @@ jobs:
         sudo apt-get install mpich libmpich-dev
         export MAKE_CXX_FLAG="MPICXX=mpic++"
 
-    # Get Hypre through cache, or install it.
+    # Get Hypre through cache, or build it.
     # Install will only run on cache miss.
-    - name: cache Hypre install
+    - name: cache hypre
       id: hypre-cache
       uses: actions/cache@v2
       with:
         path: ${{ env.HYPRE_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.HYPRE_TOP_DIR }}-v1
 
-    - name: install Hypre
+    - name: build Hypre
       if: steps.hypre-cache.outputs.cache-hit != 'true'
-      uses: ./remhos/.github/actions/install-hypre
+      uses: mfem/mfem-actions/build-hypre@master
       with:
         hypre-url: ${{ env.HYPRE_URL }}
         hypre-archive: ${{ env.HYPRE_ARCHIVE }}
         hypre-dir: ${{ env.HYPRE_TOP_DIR }}
 
-    # Get Metis through cache, or install it.
+    # Get Metis through cache, or build it.
     # Install will only run on cache miss.
-    - name: cache Metis install
+    - name: cache metis
       id: metis-cache
       uses: actions/cache@v2
       with:
         path: ${{ env.METIS_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.METIS_TOP_DIR }}-v1
 
-    - name: install Metis
+    - name: build metis
       if: steps.metis-cache.outputs.cache-hit != 'true'
-      uses: ./remhos/.github/actions/install-metis
+      uses: mfem/mfem-actions/build-metis@master
       with:
         metis-url: ${{ env.METIS_URL }}
         metis-archive: ${{ env.METIS_ARCHIVE }}
         metis-dir: ${{ env.METIS_TOP_DIR }}
 
-    # make generic links to libraries for MFEM install
-    - name: configure links
+    - name: mfem master commit
       run: |
-        echo "Hypre symlink:"
-        ln -s $HYPRE_TOP_DIR hypre;
-        echo "Metis symlink:"
-        ln -s $METIS_TOP_DIR metis-4.0;
+        echo "MFEM_COMMIT=$(git ls-remote --heads https://github.com/mfem/mfem.git master | awk '{print $1;}')" >> $GITHUB_ENV
 
-    - name: MFEM master commit
-      run: |
-        echo "MFEM_COMMIT=$(git ls-remote --heads ${{ env.MFEM_REPO }} ${{ env.MFEM_BRANCH }} | awk '{print $1;}')" >> $GITHUB_ENV
-
-    # Get MFEM through cache, or install it.
+    # Get mfem through cache, or build it.
     # Install will only run on cache miss.
-    - name: cache MFEM install
+    - name: cache mfem
       id: mfem-cache
       uses: actions/cache@v2
       with:
         path: ${{ env.MFEM_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-v2
 
-    - name: install MFEM
+    - name: build mfem
       if: steps.mfem-cache.outputs.cache-hit != 'true'
-      uses: ./remhos/.github/actions/install-mfem
+      uses: mfem/mfem-actions/build-mfem@master
       with:
-        mfem-repo: ${{ env.MFEM_REPO }}
-        mfem-branch: ${{ env.MFEM_BRANCH }}
+        os: ${{ runner.os }}
+        hypre-dir: ${{ env.HYPRE_TOP_DIR }}
+        metis-dir: ${{ env.METIS_TOP_DIR }}
         mfem-dir: ${{ env.MFEM_TOP_DIR }}
 
     - name: build Remhos

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,8 +13,8 @@ env:
   METIS_URL: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD
   METIS_ARCHIVE: metis-4.0.3.tar.gz
   METIS_TOP_DIR: metis-4.0.3
-  MFEM_BRANCH: master
   MFEM_TOP_DIR: mfem
+  MFEM_BRANCH: master
 
 jobs:
   build-and-test:
@@ -67,9 +67,9 @@ jobs:
         metis-archive: ${{ env.METIS_ARCHIVE }}
         metis-dir: ${{ env.METIS_TOP_DIR }}
 
-    - name: mfem master commit
+    - name: MFEM ${{ env.MFEM_BRANCH }} commit
       run: |
-        echo "MFEM_COMMIT=$(git ls-remote --heads https://github.com/mfem/mfem.git master | awk '{print $1;}')" >> $GITHUB_ENV
+        echo "MFEM_COMMIT=$(git ls-remote --heads https://github.com/mfem/mfem.git ${{ env.MFEM_BRANCH }} | awk '{print $1;}')" >> $GITHUB_ENV
 
     # Get mfem through cache, or build it.
     # Install will only run on cache miss.
@@ -88,6 +88,7 @@ jobs:
         hypre-dir: ${{ env.HYPRE_TOP_DIR }}
         metis-dir: ${{ env.METIS_TOP_DIR }}
         mfem-dir: ${{ env.MFEM_TOP_DIR }}
+        mfem-branch: ${{ env.MFEM_BRANCH }}
 
     - name: build Remhos
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,10 +7,8 @@ on:
   pull_request:
 
 env:
-  HYPRE_URL: https://github.com/hypre-space/hypre/archive
   HYPRE_ARCHIVE: v2.19.0.tar.gz
   HYPRE_TOP_DIR: hypre-2.19.0
-  METIS_URL: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD
   METIS_ARCHIVE: metis-4.0.3.tar.gz
   METIS_TOP_DIR: metis-4.0.3
   MFEM_TOP_DIR: mfem
@@ -46,7 +44,6 @@ jobs:
       if: steps.hypre-cache.outputs.cache-hit != 'true'
       uses: mfem/mfem-actions/build-hypre@master
       with:
-        hypre-url: ${{ env.HYPRE_URL }}
         hypre-archive: ${{ env.HYPRE_ARCHIVE }}
         hypre-dir: ${{ env.HYPRE_TOP_DIR }}
 
@@ -63,7 +60,6 @@ jobs:
       if: steps.metis-cache.outputs.cache-hit != 'true'
       uses: mfem/mfem-actions/build-metis@master
       with:
-        metis-url: ${{ env.METIS_URL }}
         metis-archive: ${{ env.METIS_ARCHIVE }}
         metis-dir: ${{ env.METIS_TOP_DIR }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.HYPRE_TOP_DIR }}
-        key: ${{ runner.os }}-build-${{ env.HYPRE_TOP_DIR }}-v1
+        key: ${{ runner.os }}-build-${{ env.HYPRE_TOP_DIR }}-v2
 
     - name: build Hypre
       if: steps.hypre-cache.outputs.cache-hit != 'true'
@@ -54,7 +54,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.METIS_TOP_DIR }}
-        key: ${{ runner.os }}-build-${{ env.METIS_TOP_DIR }}-v1
+        key: ${{ runner.os }}-build-${{ env.METIS_TOP_DIR }}-v2
 
     - name: build metis
       if: steps.metis-cache.outputs.cache-hit != 'true'
@@ -83,7 +83,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.MFEM_TOP_DIR }}
-        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-v2
+        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-v3
 
     - name: build mfem
       if: steps.mfem-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Sharing Github Actions in a dedicated repo to avoid duplication with MFEM, Laghos and GLVis.

There should be no change in the CI results due to this PR.

Relates to:
https://github.com/mfem/mfem-actions
mfem/mfem#2146
GLVis/glvis#164
https://github.com/CEED/Laghos/pull/143