### PR TITLE
code for obtaining subcell fluxes with desired sparsity pattern

### DIFF
--- a/remhos.cpp
+++ b/remhos.cpp
@@ -854,6 +854,30 @@ int main(int argc, char *argv[])
           s_max_glob = -numeric_limits<double>::infinity();
    const int NE = pmesh.GetNE();
 
+   const FiniteElement *dummy = pfes.GetFE(0);
+   const int nd = dummy->GetDof();
+
+   DenseMatrix DistMat, MassMatLOR;
+   GetDistOps(dummy, DistMat, MassMatLOR);
+
+   Vector elem_vec(nd), elem_vec_dist(nd);
+   elem_vec.Randomize();
+   double aux = elem_vec.Sum() / nd;
+   elem_vec -= aux; // sum of vector entries must be zero
+
+   ApplyDistOp(DistMat, elem_vec, elem_vec_dist);
+
+   // Testing
+   for (int i = 0; i < nd; i++)
+   {
+      for (int j = 0; j < nd; j++)
+      {
+         double f_ij = GetAntiDiffFlux(MassMatLOR, elem_vec_dist, i, j);
+         cout << f_ij << endl;
+      }
+      cout << endl;
+   }
+
    // Time-integration (loop over the time iterations, ti, with a time-step dt).
    bool done = false;
    for (int ti = 0; !done;)

--- a/remhos_tools.hpp
+++ b/remhos_tools.hpp
@@ -23,6 +23,15 @@
 namespace mfem
 {
 
+void ComputeLORMassMatRef(Geometry::Type gtype, bool UseDiagonalNbrs,
+                          DenseMatrix &RefMat);
+void GetDistOps(const FiniteElement *dummy, DenseMatrix &DistMat,
+                DenseMatrix &MassMatLOR);
+void ApplyDistOp(const DenseMatrix &DistMat, const Vector &elem_vec,
+                 Vector &elem_vec_dist);
+double GetAntiDiffFlux(const DenseMatrix &MassMatLOR,
+                       Vector &elem_vec_dist, int i, int j);
+
 int GetLocalFaceDofIndex(int dim, int loc_face_id, int face_orient,
                          int face_dof_id, int face_dof1D_cnt);
 


### PR DESCRIPTION
As discussed, I've added code for obtaining subcell fluxes from an element vector that sums to zero. Note that there is an option `bool UseDiagonalNbrs`. If this is set to false, the dense stencil of a Q_1 element reduces to a cross stencil, similar to collocated methods. If true, the stencil of Q_1 remains unchanged, in either case the stencil is generally sparse.

Since I wanted to have this option and the integrals to be computed are non-standard, I found it easier to hard-code the entries, after tedious pen-and-paper calculations.

I'm performing the "assembly" on the reference element, and omitting the multiplication and subsequent division with the transformation constant. I strongly believe that this can also be done for severely curved elements, because Manuel observed that such integration errors are way less important than obtaining the right sparsity pattern.

The new functions are called from the main routine to illustrate how to use them. I haven't worked with Remhos in a while, so somebody else needs to apply this code where it's needed. 


