### PR TITLE
Element/Partial Assembly Discrete Upwind Option

### DIFF
--- a/remhos.cpp
+++ b/remhos.cpp
@@ -390,16 +390,22 @@ int main(int argc, char *argv[])
    M_HO.AddDomainIntegrator(new MassIntegrator);
 
    ParBilinearForm k(&pfes);
+   ParBilinearForm k_du(&pfes);
    ParBilinearForm K_HO(&pfes);
+   ConvectionIntegrator *conv_int = nullptr;
    if (exec_mode == 0)
    {
+      conv_int = new ConvectionIntegrator(velocity, -1.0);
       k.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
+      k_du.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
       K_HO.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
    }
    else if (exec_mode == 1)
    {
-      k.AddDomainIntegrator(new ConvectionIntegrator(v_coef));
-      K_HO.AddDomainIntegrator(new ConvectionIntegrator(v_coef));
+      conv_int = new ConvectionIntegrator(v_coef);
+      k.AddDomainIntegrator(conv_int);
+      k_du.AddDomainIntegrator(conv_int);
+      K_HO.AddDomainIntegrator(conv_int);
    }
 
    if (ho_type == HOSolverType::CG ||
@@ -430,11 +436,14 @@ int main(int argc, char *argv[])
       K_HO.SetAssemblyLevel(AssemblyLevel::PARTIAL);
    }
 
+   k_du.SetAssemblyLevel(AssemblyLevel::PARTIAL);
+
    if (next_gen_full)
    {
       K_HO.SetAssemblyLevel(AssemblyLevel::FULL);
    }
 
+   k_du.Assemble();
    M_HO.Assemble();
    K_HO.Assemble(0);
 
@@ -613,8 +622,8 @@ int main(int argc, char *argv[])
    if (lo_type == LOSolverType::DiscrUpwind)
    {
       lo_smap = SparseMatrix_Build_smap(k.SpMat());
-      lo_solver = new DiscreteUpwind(pfes, k.SpMat(), lo_smap,
-                                     lumpedM, asmbl, time_dep);
+      lo_solver = new PADiscreteUpwind(pfes, k_du, conv_int, k.SpMat(), lo_smap,
+                                       lumpedM, asmbl, time_dep);
    }
    else if (lo_type == LOSolverType::DiscrUpwindPrec)
    {

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -621,18 +621,26 @@ int main(int argc, char *argv[])
    const bool time_dep = (exec_mode == 0) ? false : true;
    if (lo_type == LOSolverType::DiscrUpwind)
    {
-      lo_smap = SparseMatrix_Build_smap(k.SpMat());
-      lo_solver = new PADiscreteUpwind(pfes, k_du, conv_int, k.SpMat(), lo_smap,
-                                       lumpedM, asmbl, time_dep);
-
-      if (exec_mode == 0)
+      if (pa)
       {
-         const PADiscreteUpwind *lo_ptr =
-            dynamic_cast<const PADiscreteUpwind*>(lo_solver);
-         lo_ptr->SampleVelocity(FaceType::Interior);
-         lo_ptr->SampleVelocity(FaceType::Boundary);
-         lo_ptr->SetupPA(FaceType::Interior);
-         lo_ptr->SetupPA(FaceType::Boundary);
+         lo_solver = new PADiscreteUpwind(pfes, conv_int,
+                                          lumpedM, asmbl, time_dep);
+         if (exec_mode == 0)
+         {
+            const PADiscreteUpwind *lo_ptr =
+               dynamic_cast<const PADiscreteUpwind*>(lo_solver);
+            lo_ptr->AssembleBlkOperators();
+            lo_ptr->SampleVelocity(FaceType::Interior);
+            lo_ptr->SampleVelocity(FaceType::Boundary);
+            lo_ptr->SetupPA(FaceType::Interior);
+            lo_ptr->SetupPA(FaceType::Boundary);
+         }
+      }
+      else
+      {
+         lo_smap = SparseMatrix_Build_smap(k.SpMat());
+         lo_solver = new DiscreteUpwind(pfes, k.SpMat(), lo_smap,
+                                        lumpedM, asmbl, time_dep);
       }
    }
    else if (lo_type == LOSolverType::DiscrUpwindPrec)

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -624,6 +624,16 @@ int main(int argc, char *argv[])
       lo_smap = SparseMatrix_Build_smap(k.SpMat());
       lo_solver = new PADiscreteUpwind(pfes, k_du, conv_int, k.SpMat(), lo_smap,
                                        lumpedM, asmbl, time_dep);
+
+      if (exec_mode == 0)
+      {
+         const PADiscreteUpwind *lo_ptr =
+            dynamic_cast<const PADiscreteUpwind*>(lo_solver);
+         lo_ptr->SampleVelocity(FaceType::Interior);
+         lo_ptr->SampleVelocity(FaceType::Boundary);
+         lo_ptr->SetupPA(FaceType::Interior);
+         lo_ptr->SetupPA(FaceType::Boundary);
+      }
    }
    else if (lo_type == LOSolverType::DiscrUpwindPrec)
    {
@@ -1218,6 +1228,13 @@ void AdvectionOperator::Mult(const Vector &X, Vector &Y) const
          RD_ptr->SampleVelocity(FaceType::Boundary);
          RD_ptr->SetupPA(FaceType::Interior);
          RD_ptr->SetupPA(FaceType::Boundary);
+      }
+      else if (auto lo_ptr = dynamic_cast<const PADiscreteUpwind*>(lo_solver))
+      {
+         lo_ptr->SampleVelocity(FaceType::Interior);
+         lo_ptr->SampleVelocity(FaceType::Boundary);
+         lo_ptr->SetupPA(FaceType::Interior);
+         lo_ptr->SetupPA(FaceType::Boundary);
       }
       else
       {

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -390,21 +390,18 @@ int main(int argc, char *argv[])
    M_HO.AddDomainIntegrator(new MassIntegrator);
 
    ParBilinearForm k(&pfes);
-   ParBilinearForm k_du(&pfes);
    ParBilinearForm K_HO(&pfes);
    ConvectionIntegrator *conv_int = nullptr;
    if (exec_mode == 0)
    {
       conv_int = new ConvectionIntegrator(velocity, -1.0);
       k.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
-      k_du.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
       K_HO.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
    }
    else if (exec_mode == 1)
    {
       conv_int = new ConvectionIntegrator(v_coef);
       k.AddDomainIntegrator(conv_int);
-      k_du.AddDomainIntegrator(conv_int);
       K_HO.AddDomainIntegrator(conv_int);
    }
 
@@ -436,14 +433,11 @@ int main(int argc, char *argv[])
       K_HO.SetAssemblyLevel(AssemblyLevel::PARTIAL);
    }
 
-   k_du.SetAssemblyLevel(AssemblyLevel::PARTIAL);
-
    if (next_gen_full)
    {
       K_HO.SetAssemblyLevel(AssemblyLevel::FULL);
    }
 
-   k_du.Assemble();
    M_HO.Assemble();
    K_HO.Assemble(0);
 

--- a/remhos_lo.cpp
+++ b/remhos_lo.cpp
@@ -42,9 +42,8 @@ DiscreteUpwind::DiscreteUpwind(ParFiniteElementSpace &space,
 }
 
 PADiscreteUpwind::PADiscreteUpwind(ParFiniteElementSpace &space,
-                                   /*ParBilinearForm &Kbf,*/ ConvectionIntegrator *Conv_,
-                                   /*const SparseMatrix &adv,*/
-                                   /*const Array<int> &adv_smap,*/ const Vector &Mlump,
+                                   ConvectionIntegrator *Conv_,
+                                   const Vector &Mlump,
                                    Assembly &asmbly, bool timedep)
    : LOSolver(space),
      PADGTraceLOSolver(space, get_maps(pfes, asmbly)->nqpt,
@@ -53,9 +52,7 @@ PADiscreteUpwind::PADiscreteUpwind(ParFiniteElementSpace &space,
                        get_maps(pfes, asmbly)->nqpt :
                        get_maps(pfes, asmbly)->nqpt * get_maps(pfes, asmbly)->nqpt,
                        asmbly),
-     /*k_pbilinear(Kbf),*/ Conv(Conv_), /*K(adv), D(), K_smap(adv_smap), */ M_lumped(
-        Mlump),
-     time_dep(timedep)
+     Conv(Conv_), M_lumped(Mlump), time_dep(timedep)
 {
 }
 

--- a/remhos_lo.hpp
+++ b/remhos_lo.hpp
@@ -58,6 +58,53 @@ public:
    virtual void CalcLOSolution(const Vector &u, Vector &du) const;
 };
 
+class PADiscreteUpwind : public LOSolver
+{
+protected:
+   ParBilinearForm &k_pbilinear;
+   ConvectionIntegrator *Conv;
+   const SparseMatrix &K;
+   mutable SparseMatrix D;
+   const Array<int> &K_smap;
+   const Vector &M_lumped;
+   Assembly &assembly;
+   const bool update_D;
+
+   void ComputeDiscreteUpwindMatrix() const;
+
+   // Data at quadrature points //for face terms
+   const int quad1D, dofs1D, face_dofs;
+   mutable Array<double> D_int, D_bdry;
+   mutable Array<double> IntVelocity, BdryVelocity;
+
+public:
+   PADiscreteUpwind(ParFiniteElementSpace &space,
+                    ParBilinearForm &Kbf, ConvectionIntegrator *Conv_,
+                    const SparseMatrix &adv,
+                    const Array<int> &adv_smap, const Vector &Mlump,
+                    Assembly &asmbly, bool updateD);
+
+   void SampleVelocity(FaceType type) const;
+
+   void SetupPA(FaceType type) const;
+
+   void SetupPA2D(FaceType) const;
+
+   void SetupPA3D(FaceType) const;
+
+   void ApplyFaceTerms(const Vector &x, Vector &y, FaceType type) const;
+
+   void ApplyFaceTerms2D(const Vector &x, Vector &y, FaceType type) const;
+
+   void ApplyFaceTerms3D(const Vector &x, Vector &y, FaceType type) const;
+
+   void ComputeAlgebraicDiffusion(Vector &ConvMats, Vector &AlgDiff) const;
+
+   void AddBlkMult(const Vector &Mat, const Vector &x, Vector &y) const;
+
+   virtual void CalcLOSolution(const Vector &u, Vector &du) const;
+};
+
 class ResidualDistribution : public LOSolver
 {
 protected:

--- a/remhos_lo.hpp
+++ b/remhos_lo.hpp
@@ -93,20 +93,25 @@ public:
 class PADiscreteUpwind : public LOSolver, public PADGTraceLOSolver
 {
 protected:
-   ParBilinearForm &k_pbilinear;
-   ConvectionIntegrator *Conv;
-   const SparseMatrix &K;
-   mutable SparseMatrix D;
-   const Array<int> &K_smap;
+   //ParBilinearForm &k_pbilinear;
+   ConvectionIntegrator *Conv = nullptr;
+   //const SparseMatrix &K;
+   //mutable SparseMatrix D;
+   //const Array<int> &K_smap;
    const Vector &M_lumped;
    const bool time_dep;
+   mutable Vector ConvMats;
+   mutable Vector AlgDiffMats;
 
 public:
    PADiscreteUpwind(ParFiniteElementSpace &space,
-                    ParBilinearForm &Kbf, ConvectionIntegrator *Conv_,
-                    const SparseMatrix &adv,
-                    const Array<int> &adv_smap, const Vector &Mlump,
+                    /*ParBilinearForm &Kbf,*/ ConvectionIntegrator *Conv_,
+                    /* const SparseMatrix &adv,*/
+                    /*const Array<int> &adv_smap, */ const Vector &Mlump,
                     Assembly &asmbly, bool timedep);
+
+   /*Block Operators are in row major format*/
+   void AssembleBlkOperators() const;
 
    void ComputeAlgebraicDiffusion(Vector &ConvMats, Vector &AlgDiff) const;
 

--- a/remhos_lo.hpp
+++ b/remhos_lo.hpp
@@ -49,11 +49,11 @@ protected:
    Assembly &trace_assembly;
 
 public:
-     PADGTraceLOSolver(ParFiniteElementSpace &pfes_, const int q1D,
-                       const int d1D, const int fdofs,
-                       Assembly &assembly_) :
-     trace_pfes(pfes_), quad1D(q1D), dofs1D(d1D), face_dofs(fdofs),
-     trace_assembly(assembly_) {}
+   PADGTraceLOSolver(ParFiniteElementSpace &pfes_, const int q1D,
+                     const int d1D, const int fdofs,
+                     Assembly &assembly_) :
+      trace_pfes(pfes_), quad1D(q1D), dofs1D(d1D), face_dofs(fdofs),
+      trace_assembly(assembly_) {}
 
    void SampleVelocity(FaceType type) const;
 
@@ -90,7 +90,7 @@ public:
    virtual void CalcLOSolution(const Vector &u, Vector &du) const;
 };
 
-class PADiscreteUpwind : public LOSolver
+class PADiscreteUpwind : public LOSolver, public PADGTraceLOSolver
 {
 protected:
    ParBilinearForm &k_pbilinear;
@@ -99,22 +99,14 @@ protected:
    mutable SparseMatrix D;
    const Array<int> &K_smap;
    const Vector &M_lumped;
-   Assembly &assembly;
-   const bool update_D;
-
-   void ComputeDiscreteUpwindMatrix() const;
-
-   // Data at quadrature points //for face terms
-   const int quad1D, dofs1D, face_dofs;
-   mutable Array<double> D_int, D_bdry;
-   mutable Array<double> IntVelocity, BdryVelocity;
+   const bool time_dep;
 
 public:
    PADiscreteUpwind(ParFiniteElementSpace &space,
                     ParBilinearForm &Kbf, ConvectionIntegrator *Conv_,
                     const SparseMatrix &adv,
                     const Array<int> &adv_smap, const Vector &Mlump,
-                    Assembly &asmbly, bool updateD);
+                    Assembly &asmbly, bool timedep);
 
    void ComputeAlgebraicDiffusion(Vector &ConvMats, Vector &AlgDiff) const;
 
@@ -141,7 +133,8 @@ public:
 };
 
 //PA based Residual Distribution
-class PAResidualDistribution : public ResidualDistribution , public PADGTraceLOSolver
+class PAResidualDistribution : public ResidualDistribution,
+   public PADGTraceLOSolver
 {
 protected:
 

--- a/remhos_lo.hpp
+++ b/remhos_lo.hpp
@@ -93,11 +93,7 @@ public:
 class PADiscreteUpwind : public LOSolver, public PADGTraceLOSolver
 {
 protected:
-   //ParBilinearForm &k_pbilinear;
    ConvectionIntegrator *Conv = nullptr;
-   //const SparseMatrix &K;
-   //mutable SparseMatrix D;
-   //const Array<int> &K_smap;
    const Vector &M_lumped;
    const bool time_dep;
    mutable Vector ConvMats;
@@ -105,9 +101,8 @@ protected:
 
 public:
    PADiscreteUpwind(ParFiniteElementSpace &space,
-                    /*ParBilinearForm &Kbf,*/ ConvectionIntegrator *Conv_,
-                    /* const SparseMatrix &adv,*/
-                    /*const Array<int> &adv_smap, */ const Vector &Mlump,
+                    ConvectionIntegrator *Conv_,
+                    const Vector &Mlump,
                     Assembly &asmbly, bool timedep);
 
    /*Block Operators are in row major format*/

--- a/remhos_lo.hpp
+++ b/remhos_lo.hpp
@@ -38,6 +38,38 @@ public:
 
 class Assembly;
 
+class PADGTraceLOSolver
+{
+protected:
+   // Data at quadrature points
+   ParFiniteElementSpace &trace_pfes;
+   const int quad1D, dofs1D, face_dofs;
+   mutable Array<double> D_int, D_bdry;
+   mutable Array<double> IntVelocity, BdryVelocity;
+   Assembly &trace_assembly;
+
+public:
+     PADGTraceLOSolver(ParFiniteElementSpace &pfes_, const int q1D,
+                       const int d1D, const int fdofs,
+                       Assembly &assembly_) :
+     trace_pfes(pfes_), quad1D(q1D), dofs1D(d1D), face_dofs(fdofs),
+     trace_assembly(assembly_) {}
+
+   void SampleVelocity(FaceType type) const;
+
+   void SetupPA(FaceType type) const;
+
+   void SetupPA2D(FaceType) const;
+
+   void SetupPA3D(FaceType) const;
+
+   void ApplyFaceTerms(const Vector &x, Vector &y, FaceType type) const;
+
+   void ApplyFaceTerms2D(const Vector &x, Vector &y, FaceType type) const;
+
+   void ApplyFaceTerms3D(const Vector &x, Vector &y, FaceType type) const;
+};
+
 class DiscreteUpwind : public LOSolver
 {
 protected:
@@ -84,20 +116,6 @@ public:
                     const Array<int> &adv_smap, const Vector &Mlump,
                     Assembly &asmbly, bool updateD);
 
-   void SampleVelocity(FaceType type) const;
-
-   void SetupPA(FaceType type) const;
-
-   void SetupPA2D(FaceType) const;
-
-   void SetupPA3D(FaceType) const;
-
-   void ApplyFaceTerms(const Vector &x, Vector &y, FaceType type) const;
-
-   void ApplyFaceTerms2D(const Vector &x, Vector &y, FaceType type) const;
-
-   void ApplyFaceTerms3D(const Vector &x, Vector &y, FaceType type) const;
-
    void ComputeAlgebraicDiffusion(Vector &ConvMats, Vector &AlgDiff) const;
 
    void AddBlkMult(const Vector &Mat, const Vector &x, Vector &y) const;
@@ -123,32 +141,14 @@ public:
 };
 
 //PA based Residual Distribution
-class PAResidualDistribution : public ResidualDistribution
+class PAResidualDistribution : public ResidualDistribution , public PADGTraceLOSolver
 {
 protected:
-   // Data at quadrature points
-   const int quad1D, dofs1D, face_dofs;
-   mutable Array<double> D_int, D_bdry;
-   mutable Array<double> IntVelocity, BdryVelocity;
 
 public:
    PAResidualDistribution(ParFiniteElementSpace &space, ParBilinearForm &Kbf,
                           Assembly &asmbly, const Vector &Mlump,
                           bool subcell, bool timedep);
-
-   void SampleVelocity(FaceType type) const;
-
-   void SetupPA(FaceType type) const;
-
-   void SetupPA2D(FaceType) const;
-
-   void SetupPA3D(FaceType) const;
-
-   void ApplyFaceTerms(const Vector &x, Vector &y, FaceType type) const;
-
-   void ApplyFaceTerms2D(const Vector &x, Vector &y, FaceType type) const;
-
-   void ApplyFaceTerms3D(const Vector &x, Vector &y, FaceType type) const;
 
    virtual void CalcLOSolution(const Vector &u, Vector &du) const;
 };


### PR DESCRIPTION
Adds option to perform discrete upwind global matrix free -- uses element assembly for the discrete upwind terms and PA for face lumping.

Notes: I refactored the residual distribution classes to derive from DGFaceTerm class as it also used for discrete upwind