### PR TITLE
Bounds-preserving time integration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,6 +94,7 @@ jobs:
         metis-dir: ${{ env.METIS_TOP_DIR }}
         mfem-dir: ${{ env.MFEM_TOP_DIR }}
         mfem-branch: ${{ env.MFEM_BRANCH }}
+        library-only: 'true'
 
     - name: build Remhos
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
     # Install will only run on cache miss.
     - name: cache hypre
       id: hypre-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ env.HYPRE_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.HYPRE_TOP_DIR }}-v2
@@ -51,7 +51,7 @@ jobs:
     # Install will only run on cache miss.
     - name: cache metis
       id: metis-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ env.METIS_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.METIS_TOP_DIR }}-v2
@@ -80,7 +80,7 @@ jobs:
     # Install will only run on cache miss.
     - name: cache mfem
       id: mfem-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ env.MFEM_TOP_DIR }}
         key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-v3
@@ -115,7 +115,7 @@ jobs:
 
     - name: Archive test results patch
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: baseline-patch
         path: remhos/baseline.patch

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     # Checkout Remhos in "remhos" subdirectory. Final path: /home/runner/work/remhos/remhos/remhos

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Archive test results patch
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: baseline-patch
         path: remhos/baseline.patch

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+remhos
+*.mesh
+*.gf

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Alternatively, verify the final mass (`mass`) and maximum value (`max`) for the 
 7.  `mpirun -np 8 remhos -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.014 -tf 8 -ho 1 -lo 4 -fct 2`
 8.  `mpirun -np 8 remhos -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.02 -tf 3 -ho 1 -lo 4 -fct 2`
 9.  `mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.001 -tf 0.75 -ho 1 -lo 4 -fct 2`
-10. `mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps`
+10. `mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 14 -rs 3 -dt 0.005 -tf 0.75 -ho 1 -lo 5 -fct 4 -ps -s 13`
 11. `mpirun -np 8 remhos -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.8 -ho 1 -lo 4 -fct 2`
 12. `mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 7 -rs 3 -o 1 -dt 0.01 -tf 20 -mono 1 -si 2`
 13. `mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 6 -rs 2 -o 1 -dt 0.01 -tf 20 -mono 1 -si 1`
@@ -250,7 +250,7 @@ Alternatively, verify the final mass (`mass`) and maximum value (`max`) for the 
 |  7. | 0.9607429525 | 0.7678305756 |
 |  8. | 0.8087104604 | 0.9999889315 |
 |  9. | 0.08479546709| 0.8156091428 |
-| 10. | 0.08980397023| 0.9886734209 |
+| 10. | 0.09317738757| 0.9994170644 |
 | 11. | 0.1197294512 | 0.9990312449 |
 | 12. | 0.1570667907 | 0.9987771164 |
 | 13. | 0.3182739921 | 1            |

--- a/autotest/out_baseline.dat
+++ b/autotest/out_baseline.dat
@@ -185,19 +185,19 @@ Final mass u:  0.8143001155
 Max value u:   0.9995762608
 
 --- Product remap 2D (FCT)
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps
-Final mass us: 0.1796082878
-Mass loss us:  4.15262e-07
+mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 13
+Final mass us: 0.1767475452
+Mass loss us:  0.00286033
 
 --- Product remap 2D (ClipScale)
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 2 -ps -s 1
-Final mass us: 0.1814773886
-Mass loss us:  0.00186952
+mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 2 -ps -s 13
+Final mass us: 0.1782170448
+Mass loss us:  0.00139083
 
 --- Product remap 2D (FCTProject)
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 4 -ps -s 1
-Final mass us: 0.1814920761
-Mass loss us:  0.0018842
+mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 4 -ps -s 13
+Final mass us: 0.1776386793
+Mass loss us:  0.00196919
 
 --- BLAST sharpening test - Pacman remap auto-dt
 mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 1 -dt -1 -tf 0.75 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1

--- a/autotest/out_baseline.dat
+++ b/autotest/out_baseline.dat
@@ -2,215 +2,219 @@
 --- Method -ho 1 -lo 2 -fct 2
 
 - Remap pacman nonper-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 1 -lo 2 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 1 -lo 2 -fct 2
 Final mass u:  0.08479546635
 Max value u:   0.8262759545
 
 - Remap bump nonper-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 1 -lo 2 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 1 -lo 2 -fct 2
 Final mass u:  0.1197299711
 Max value u:   0.9998930413
 
 - Transport per-1D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 1 -lo 2 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 1 -lo 2 -fct 2
 Final mass u:  0.1401241455
 Max value u:   0.9052498201
 
 - Transport bump per-unstruct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 1 -lo 2 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 1 -lo 2 -fct 2
 Final mass u:  0.3888354875
 Max value u:   0.9854644631
 
 - Transport balls-jacks per-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 1 -lo 2 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 1 -lo 2 -fct 2
 Final mass u:  0.1623263888
 Max value u:   0.7742737139
 
 - Transport bump per-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 1 -lo 2 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 1 -lo 2 -fct 2
 Final mass u:  0.9607429525
 Max value u:   0.9724537077
 
 - Transport bump nonper-unstruct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 1 -lo 2 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 1 -lo 2 -fct 2
 Final mass u:  0.8075105661
 Max value u:   0.9999889304
 
 --- Method -ho 3 -lo 4 -fct 2
 
 - Remap pacman nonper-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 3 -lo 4 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 3 -lo 4 -fct 2
 Final mass u:  0.0847954729
 Max value u:   0.7581364675
 
 - Remap bump nonper-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 3 -lo 4 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 3 -lo 4 -fct 2
 Final mass u:  0.1197299801
 Max value u:   0.9997499683
 
 - Transport per-1D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 3 -lo 4 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 3 -lo 4 -fct 2
 Final mass u:  0.1401241455
 Max value u:   0.9039764015
 
 - Transport bump per-unstruct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 3 -lo 4 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 3 -lo 4 -fct 2
 Final mass u:  0.3888354875
 Max value u:   0.9850024108
 
 - Transport balls-jacks per-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 3 -lo 4 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 3 -lo 4 -fct 2
 Final mass u:  0.1623263888
 Max value u:   0.7145371968
 
 - Transport bump per-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 3 -lo 4 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 3 -lo 4 -fct 2
 Final mass u:  0.9607429525
 Max value u:   0.9334903111
 
 - Transport bump nonper-unstruct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 3 -lo 4 -fct 2
+mpirun -np 2 ./remhos -no-vis -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 3 -lo 4 -fct 2
 Final mass u:  0.814998186
 Max value u:   0.9999889315
 
 --- Method -ho 2 -lo 3 -fct 2 -pa
 
 - Remap pacman nonper-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 2 -lo 3 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 2 -lo 3 -fct 2 -pa
 Final mass u:  0.08479546775
 Max value u:   0.7779015453
 
 - Remap bump nonper-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 2 -lo 3 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 2 -lo 3 -fct 2 -pa
 Final mass u:  0.1197300033
 Max value u:   0.9997879406
 
 - Transport per-1D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 2 -lo 3 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 2 -lo 3 -fct 2 -pa
 Final mass u:  0.1401241455
 Max value u:   0.8781060808
 
 - Transport bump per-unstruct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 2 -lo 3 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 2 -lo 3 -fct 2 -pa
 Final mass u:  0.3888354875
 Max value u:   0.9755502191
 
 - Transport balls-jacks per-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 2 -lo 3 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 2 -lo 3 -fct 2 -pa
 Final mass u:  0.1623263888
 Max value u:   0.6374820899
 
 - Transport bump per-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 2 -lo 3 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 2 -lo 3 -fct 2 -pa
 Final mass u:  0.9607429525
 Max value u:   0.9202929163
 
 - Transport bump nonper-unstruct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 2 -lo 3 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 2 -lo 3 -fct 2 -pa
 Final mass u:  0.7772459527
 Max value u:   0.9999889307
 
 --- Method -ho 2 -lo 4 -fct 2 -pa
 
 - Remap pacman nonper-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 2 -lo 4 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 2 -lo 4 -fct 2 -pa
 Final mass u:  0.0847954729
 Max value u:   0.7581364676
 
 - Remap bump nonper-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 2 -lo 4 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 2 -lo 4 -fct 2 -pa
 Final mass u:  0.1197299801
 Max value u:   0.9997499683
 
 - Transport per-1D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 2 -lo 4 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 2 -lo 4 -fct 2 -pa
 Final mass u:  0.1401241455
 Max value u:   0.9039764015
 
 - Transport bump per-unstruct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 2 -lo 4 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 2 -lo 4 -fct 2 -pa
 Final mass u:  0.3888354875
 Max value u:   0.9850024108
 
 - Transport balls-jacks per-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 2 -lo 4 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 2 -lo 4 -fct 2 -pa
 Final mass u:  0.1623263888
 Max value u:   0.7145371968
 
 - Transport bump per-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 2 -lo 4 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 2 -lo 4 -fct 2 -pa
 Final mass u:  0.9607429525
 Max value u:   0.9334903111
 
 - Transport bump nonper-unstruct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 2 -lo 4 -fct 2 -pa
+mpirun -np 2 ./remhos -no-vis -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 2 -lo 4 -fct 2 -pa
 Final mass u:  0.7779917929
 Max value u:   0.9999889315
 
 --- Method -ho 3 -lo 1 -fct 1
 
 - Remap pacman nonper-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 3 -lo 1 -fct 1
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 1 -dt 0.0015 -tf 0.75 -ho 3 -lo 1 -fct 1
 Final mass u:  0.08479546845
 Max value u:   0.905654904
 
 - Remap bump nonper-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 3 -lo 1 -fct 1
+mpirun -np 2 ./remhos -no-vis -m ./data/cube01_hex.mesh -p 10 -rs 1 -o 2 -dt 0.02 -tf 0.7 -ho 3 -lo 1 -fct 1
 Final mass u:  0.11972981
 Max value u:   0.996173945
 
 - Transport per-1D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 3 -lo 1 -fct 1
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-segment.mesh -p 0 -rs 3 -dt 0.001 -tf 1 -ho 3 -lo 1 -fct 1
 Final mass u:  0.1401241455
 Max value u:   0.9071157249
 
 - Transport bump per-unstruct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 3 -lo 1 -fct 1
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-hexagon.mesh -p 0 -rs 2 -dt 0.005 -tf 2.5 -ho 3 -lo 1 -fct 1
 Final mass u:  0.3888354875
 Max value u:   0.9979069772
 
 - Transport balls-jacks per-struct-2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 3 -lo 1 -fct 1
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.004 -tf 0.8 -ho 3 -lo 1 -fct 1
 Final mass u:  0.1623263888
 Max value u:   0.787875182
 
 - Transport bump per-struct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 3 -lo 1 -fct 1
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-cube.mesh -p 0 -rs 1 -o 2 -dt 0.015 -tf 2 -ho 3 -lo 1 -fct 1
 Final mass u:  0.9607429525
 Max value u:   0.9984668427
 
 - Transport bump nonper-unstruct-3D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 3 -lo 1 -fct 1
+mpirun -np 2 ./remhos -no-vis -m ../mfem/data/ball-nurbs.mesh -p 1 -rs 1 -dt 0.035 -tf 3 -ho 3 -lo 1 -fct 1
 Final mass u:  0.8143001155
 Max value u:   0.9995762608
 
 --- Product remap 2D (FCT)
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 13
-Final mass us: 0.1767475452
-Mass loss us:  0.00286033
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 1
+Final mass us: 0.1815368098
+Mass loss us:  0.00192894
 
---- Product remap 2D (ClipScale)
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 2 -ps -s 13
-Final mass us: 0.1782170448
-Mass loss us:  0.00139083
+--- Product remap 2D IDP2 (ClipScale)
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 1 -lo 5 -fct 2 -ps -s 12
+Final mass us: 0.1796076412
+Mass loss us:  2.31348e-07
 
---- Product remap 2D (FCTProject)
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 4 -ps -s 13
-Final mass us: 0.1776386793
-Mass loss us:  0.00196919
+--- Product remap 2D IDP3 (FCTProject)
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 5 -fct 4 -ps -s 13
+Final mass us: 0.179607829
+Mass loss us:  4.35885e-08
 
 --- BLAST sharpening test - Pacman remap auto-dt
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 14 -rs 1 -dt -1 -tf 0.75 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 1 -dt -1 -tf 0.75 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1
+Final mass u:  0.08479612805
+Mass loss u:   6.61247e-07
 
 --- BLAST sharpening test - Transport balls-jacks auto-dt
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/periodic-square.mesh -p 5 -rs 3 -dt -1 -tf 0.8 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1
+mpirun -np 2 ./remhos -no-vis -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.01 -tf 0.8 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1
+Final mass u:  0.1623263888
+Mass loss u:   1.38778e-15
 
 --- Steady monolithic 2 2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 7 -rs 3 -o 1 -dt 0.01 -tf 20 -mono 1 -si 2
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 7 -rs 3 -o 1 -dt 0.01 -tf 20 -mono 1 -si 2
 Final mass u:  0.1570667907
 Max value u:   0.9987771164
 
 --- Steady monolithic 1 2D
-mpirun -np 2 ./remhos -no-vis --verify-bounds -m ./data/inline-quad.mesh -p 6 -rs 2 -o 1 -dt 0.01 -tf 20 -mono 1 -si 1
+mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 6 -rs 2 -o 1 -dt 0.01 -tf 20 -mono 1 -si 1
 Final mass u:  0.3182739921
 Max value u:   1

--- a/autotest/out_baseline.dat
+++ b/autotest/out_baseline.dat
@@ -196,8 +196,8 @@ Mass loss us:  2.31348e-07
 
 --- Product remap 2D IDP3 (FCTProject)
 mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 5 -fct 4 -ps -s 13
+Final mass u:  0.08980386855
 Final mass us: 0.179607829
-Mass loss us:  4.35885e-08
 
 --- BLAST sharpening test - Pacman remap auto-dt
 mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 14 -rs 1 -dt -1 -tf 0.75 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1
@@ -207,7 +207,7 @@ Mass loss u:   6.61247e-07
 --- BLAST sharpening test - Transport balls-jacks auto-dt
 mpirun -np 2 ./remhos -no-vis -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.01 -tf 0.8 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1
 Final mass u:  0.1623263888
-Mass loss u:   1.38778e-15
+Max value u:   0.2863317261
 
 --- Steady monolithic 2 2D
 mpirun -np 2 ./remhos -no-vis -m ./data/inline-quad.mesh -p 7 -rs 3 -o 1 -dt 0.01 -tf 20 -mono 1 -si 2

--- a/autotest/test.sh
+++ b/autotest/test.sh
@@ -66,17 +66,17 @@ for method in "${methods[@]}"; do
 done
 
 echo -e '\n'"--- Product remap 2D (FCT)" >> $file
-run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps"
+run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 13"
 echo -e $run_line >> $file
 $run_line | grep -e 'mass us' -e 'loss us'>> $file
 
 echo -e '\n'"--- Product remap 2D (ClipScale)" >> $file
-run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 2 -ps -s 1"
+run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 2 -ps -s 13"
 echo -e $run_line >> $file
 $run_line | grep -e 'mass us' -e 'loss us'>> $file
 
 echo -e '\n'"--- Product remap 2D (FCTProject)" >> $file
-run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 4 -ps -s 1"
+run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 4 -ps -s 13"
 echo -e $run_line >> $file
 $run_line | grep -e 'mass us' -e 'loss us'>> $file
 

--- a/autotest/test.sh
+++ b/autotest/test.sh
@@ -78,7 +78,7 @@ $run_line | grep -e 'mass us' -e 'loss us'>> $file
 echo -e '\n'"--- Product remap 2D IDP3 (FCTProject)" >> $file
 run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 5 -fct 4 -ps -s 13"
 echo -e $run_line >> $file
-$run_line | grep -e 'mass us' -e 'loss us'>> $file
+$run_line | grep -e 'mass u' -e 'mass us'>> $file
 
 echo -e '\n'"--- BLAST sharpening test - Pacman remap auto-dt" >> $file
 run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 1 -dt -1 -tf 0.75 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1"
@@ -88,7 +88,7 @@ $run_line | grep -e 'mass u' -e 'loss u'>> $file
 echo -e '\n'"--- BLAST sharpening test - Transport balls-jacks auto-dt" >> $file
 run_line=$command" -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.01 -tf 0.8 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1"
 echo -e $run_line >> $file
-$run_line | grep -e 'mass u' -e 'loss u'>> $file
+$run_line | grep -e 'mass u' -e 'value u'>> $file
 
 echo -e '\n'"--- Steady monolithic 2 2D" >> $file
 run_line=$command" -m ./data/inline-quad.mesh -p 7 -rs 3 -o 1 -dt 0.01 -tf 20 -mono 1 -si 2"

--- a/autotest/test.sh
+++ b/autotest/test.sh
@@ -9,9 +9,9 @@ file="autotest/out_test.dat"
 ntask=$1
 
 if [ "$2" = "cuda" ]; then
-  command="lrun -n "$((ntask))" ./remhos -no-vis --verify-bounds -d cuda"
+  command="lrun -n "$((ntask))" ./remhos -no-vis -d cuda"
 else
-  command="mpirun -np "$((ntask))" ./remhos -no-vis --verify-bounds"
+  command="mpirun -np "$((ntask))" ./remhos -no-vis"
 fi
 
 methods=( "-ho 1 -lo 2 -fct 2"     # Hennes 1
@@ -66,29 +66,29 @@ for method in "${methods[@]}"; do
 done
 
 echo -e '\n'"--- Product remap 2D (FCT)" >> $file
-run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 13"
+run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 1"
 echo -e $run_line >> $file
 $run_line | grep -e 'mass us' -e 'loss us'>> $file
 
-echo -e '\n'"--- Product remap 2D (ClipScale)" >> $file
-run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 2 -ps -s 13"
+echo -e '\n'"--- Product remap 2D IDP2 (ClipScale)" >> $file
+run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 1 -lo 5 -fct 2 -ps -s 12"
 echo -e $run_line >> $file
 $run_line | grep -e 'mass us' -e 'loss us'>> $file
 
-echo -e '\n'"--- Product remap 2D (FCTProject)" >> $file
-run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 1 -fct 4 -ps -s 13"
+echo -e '\n'"--- Product remap 2D IDP3 (FCTProject)" >> $file
+run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 2 -dt 0.005 -tf 0.75 -ho 3 -lo 5 -fct 4 -ps -s 13"
 echo -e $run_line >> $file
 $run_line | grep -e 'mass us' -e 'loss us'>> $file
 
 echo -e '\n'"--- BLAST sharpening test - Pacman remap auto-dt" >> $file
 run_line=$command" -m ./data/inline-quad.mesh -p 14 -rs 1 -dt -1 -tf 0.75 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1"
 echo -e $run_line >> $file
-$run_line | grep -e 'mass us' -e 'loss us'>> $file
+$run_line | grep -e 'mass u' -e 'loss u'>> $file
 
 echo -e '\n'"--- BLAST sharpening test - Transport balls-jacks auto-dt" >> $file
-run_line=$command" -m ./data/periodic-square.mesh -p 5 -rs 3 -dt -1 -tf 0.8 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1"
+run_line=$command" -m ./data/periodic-square.mesh -p 5 -rs 3 -dt 0.01 -tf 0.8 -ho 3 -lo 5 -fct 4 -bt 1 -dtc 1"
 echo -e $run_line >> $file
-$run_line | grep -e 'mass us' -e 'loss us'>> $file
+$run_line | grep -e 'mass u' -e 'loss u'>> $file
 
 echo -e '\n'"--- Steady monolithic 2 2D" >> $file
 run_line=$command" -m ./data/inline-quad.mesh -p 7 -rs 3 -o 1 -dt 0.01 -tf 20 -mono 1 -si 2"

--- a/makefile
+++ b/makefile
@@ -106,11 +106,11 @@ CCC  = $(strip $(CXX) $(REMHOS_FLAGS))
 Ccc  = $(strip $(CC) $(CFLAGS) $(GL_OPTS))
 
 SOURCE_FILES = remhos.cpp remhos_tools.cpp remhos_lo.cpp remhos_ho.cpp \
-  remhos_fct.cpp remhos_mono.cpp remhos_sync.cpp
+  remhos_fct.cpp remhos_mono.cpp remhos_sync.cpp remhos_solvers.cpp
 OBJECT_FILES1 = $(SOURCE_FILES:.cpp=.o)
 OBJECT_FILES = $(OBJECT_FILES1:.c=.o)
 HEADER_FILES = remhos_tools.hpp remhos_lo.hpp remhos_ho.hpp remhos_fct.hpp \
-  remhos_mono.hpp remhos_sync.hpp
+  remhos_mono.hpp remhos_sync.hpp remhos_solvers.hpp
 
 # Targets
 

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -925,7 +925,7 @@ int main(int argc, char *argv[])
                          ho_solver, lo_solver, fct_solver, mono_solver);
 
    adv.verify_bounds = verify_bounds;
-   fct_solver->verify_bounds = verify_bounds;
+   if (fct_solver) { fct_solver->verify_bounds = verify_bounds; }
 
    double t = 0.0;
    adv.SetTime(t);

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -330,7 +330,12 @@ int main(int argc, char *argv[])
          cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          return 3;
    }
-   if (ode_solver_type > 10) { ode_solver = idp_ode_solver; }
+   if (ode_solver_type > 10)
+   {
+      auto rk_idp = dynamic_cast<RKIDPSolver *>(idp_ode_solver);
+      if (rk_idp) { rk_idp->UseMask(true); }
+      ode_solver = idp_ode_solver;
+   }
 
    // Check if the input mesh is periodic.
    const bool periodic = pmesh.GetNodes() != NULL &&
@@ -929,6 +934,9 @@ int main(int argc, char *argv[])
 
    double u_min, u_max;
    GetMinMax(u, u_min, u_max);
+   double s_min = numeric_limits<double>::infinity(),
+          s_max = -numeric_limits<double>::infinity();
+   if (product_sync) { ComputeMinMaxS(NE, us, u, s_min, s_max); }
 
    if (exec_mode == 1)
    {
@@ -940,8 +948,6 @@ int main(int argc, char *argv[])
 
    ParGridFunction res = u;
    double residual = 0.0;
-   double s_min = numeric_limits<double>::infinity(),
-          s_max = -numeric_limits<double>::infinity();
 
    // Time-integration (loop over the time iterations, ti, with a time-step dt).
    bool done = false;

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -982,6 +982,7 @@ int main(int argc, char *argv[])
          // now we have implemented only the minimum global bound.
          u.HostRead();
          us.HostReadWrite();
+#if 0
          const int s = u.Size();
          Array<bool> active_elem, active_dofs;
          ComputeBoolIndicators(NE, u, active_elem, active_dofs);
@@ -990,8 +991,9 @@ int main(int argc, char *argv[])
             if (active_dofs[i] == false) { continue; }
 
             double us_min = u(i) * s_min_glob;
-            //if (us(i) < us_min) { us(i) = us_min; }
+            if (us(i) < us_min) { us(i) = us_min; }
          }
+#endif
 
 #ifdef REMHOS_FCT_PRODUCT_DEBUG
          ComputeMinMaxS(NE, us, u, s_min_glob, s_max_glob);

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -313,7 +313,7 @@ int main(int argc, char *argv[])
       case 2: ode_solver = new RK2IDPSolver(); break;
       case 3: ode_solver = new RK3IDPSolver(); break;
       case 4: ode_solver = new RK4IDPSolver(); break;
-      case 6: ode_solver = new RK6IDPSolver(); break;//does not work properly!
+      case 6: ode_solver = new RK6IDPSolver(); break;
       default:
          cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          return 3;

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -1436,10 +1436,11 @@ void AdvectionOperator::Mult(const Vector &X, Vector &Y) const
                                     s_bool_el_new, s_bool_dofs_new, d_us);
 
 #ifdef REMHOS_FCT_PRODUCT_DEBUG
-         Vector us_new(size);
+         Vector us_new(size), s_new(size);
          add(1.0, us, dt, d_us, us_new);
          std::cout << "      out: ";
-         ComputeMinMaxS(NE, us_new, u_new, myid);
+         ComputeRatio(NE, us_new, u_new, s_new, s_bool_el_new, s_bool_dofs_new);
+         ComputeMinMaxS(s_new, s_bool_dofs_new, myid);
 #endif
       }
       else if (lo_solver) { lo_solver->CalcLOSolution(us, d_us); }

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -311,9 +311,7 @@ int main(int argc, char *argv[])
       case 2: ode_solver = new RK2IDPSolver(); break;
       case 3: ode_solver = new RK3IDPSolver(); break;
       case 4: ode_solver = new RK4IDPSolver(); break;
-      /*case 6:
-         if (myid == 0) { MFEM_WARNING("RK6 may violate the bounds."); }
-         ode_solver = new RK6Solver; break;*/
+      case 6: ode_solver = new RK6IDPSolver(); break;//does not work properly!
       default:
          cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          return 3;

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -26,6 +26,8 @@
 // equations that are used to perform discontinuous field interpolation (remap)
 // as part of the Eulerian phase in Arbitrary-Lagrangian Eulerian (ALE)
 // simulations.
+//
+// Sample runs: see README.md, section 'Verification of Results'.
 
 #include "mfem.hpp"
 #include <fstream>

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -134,7 +134,13 @@ public:
       dt_control = tsc;
    }
 
-   void SetDt(double _dt) override { LimitedTimeDependentOperator::SetDt(_dt); dt_est = dt; }
+   void SetDt(double _dt) override
+   {
+      LimitedTimeDependentOperator::SetDt(_dt);
+      dt_est = dt;
+      if (lo_solver)  { lo_solver->UpdateTimeStep(dt); }
+      if (fct_solver) { fct_solver->UpdateTimeStep(dt); }
+   }
 
    double GetTimeStepEstimate() { return dt_est; }
 
@@ -931,8 +937,6 @@ int main(int argc, char *argv[])
 
       // This also resets the time step estimate when automatic dt is on.
       adv.SetDt(dt_real);
-      if (lo_solver)  { lo_solver->UpdateTimeStep(dt_real); }
-      if (fct_solver) { fct_solver->UpdateTimeStep(dt_real); }
 
       if (product_sync)
       {

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -1132,6 +1132,14 @@ int main(int argc, char *argv[])
            << " (" << ti_total-ti << " repeated)." << endl;
    }
 
+   // Move to the final mesh position
+   if (exec_mode == 1)
+   {
+      add(x0, t_final, v_gf, x);
+      // Reset precomputed geometric data.
+      pmesh.DeleteGeometricFactors();
+   }
+
    // Print the final meshes and solution.
    {
       ofstream meshHO("meshHO_final.mesh");

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -1470,7 +1470,7 @@ void AdvectionOperator::LimitMult(const Vector &X, Vector &Y) const
 #ifdef REMHOS_FCT_PRODUCT_DEBUG
          const int myid = x_gf.ParFESpace()->GetMyRank();
          if (myid == 0) { std::cout << "      --- RK stage" << std::endl; }
-         std::cout << "      in:  ";
+         if (myid == 0) { std::cout << "      in:  "; }
          ComputeMinMaxS(s, s_bool_dofs, myid);
 #endif
 
@@ -1496,7 +1496,7 @@ void AdvectionOperator::LimitMult(const Vector &X, Vector &Y) const
 #ifdef REMHOS_FCT_PRODUCT_DEBUG
          Vector us_new(size), s_new(size);
          add(1.0, us, dt, d_us, us_new);
-         std::cout << "      out: ";
+         if (myid == 0) { std::cout << "      out: "; }
          ComputeRatio(NE, us_new, u_new, s_new, s_bool_el_new, s_bool_dofs_new);
          ComputeMinMaxS(s_new, s_bool_dofs_new, myid);
 #endif

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -26,12 +26,6 @@
 // equations that are used to perform discontinuous field interpolation (remap)
 // as part of the Eulerian phase in Arbitrary-Lagrangian Eulerian (ALE)
 // simulations.
-//
-// single step:
-// mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 14 -rs 3 -dt 0.002 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 1 -vs 20
-// RK2:
-// mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 14 -rs 3 -dt 0.002 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 2 -vs 20
-//
 
 #include "mfem.hpp"
 #include <fstream>

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -95,7 +95,7 @@ private:
    mutable ParGridFunction x_gf;
 
    TimeStepControl dt_control;
-   mutable double dt_est;
+   mutable real_t dt_est;
    Assembly &asmbl;
 
    LowOrderMethod &lom;
@@ -136,7 +136,7 @@ public:
       dt_control = tsc;
    }
 
-   void SetDt(double _dt) override
+   void SetDt(real_t _dt) override
    {
       LimitedTimeDependentOperator::SetDt(_dt);
       dt_est = dt;
@@ -144,7 +144,7 @@ public:
       if (fct_solver) { fct_solver->UpdateTimeStep(dt); }
    }
 
-   double GetTimeStepEstimate() { return dt_est; }
+   real_t GetTimeStepEstimate() { return dt_est; }
 
    void SetRemapStartPos(const Vector &m_pos, const Vector &sm_pos)
    {

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -79,7 +79,7 @@ double inflow_function(const Vector &x);
 // Mesh bounding box
 Vector bb_min, bb_max;
 
-class AdvectionOperator : public TimeDependentOperator
+class AdvectionOperator : public LimitedTimeDependentOperator
 {
 private:
    BilinearForm &Mbf, &ml;
@@ -119,7 +119,12 @@ public:
                      HOSolver *hos, LOSolver *los, FCTSolver *fct,
                      MonolithicSolver *mos);
 
-   virtual void Mult(const Vector &x, Vector &y) const;
+   void Mult(const Vector &x, Vector &y) const override;
+
+   void MultUnlimited(const Vector &x, Vector &y) const override
+   { Mult(x, y); }
+
+   void LimitMult(const Vector &x, Vector &y) const override { }
 
    void SetTimeStepControl(TimeStepControl tsc)
    {
@@ -291,18 +296,18 @@ int main(int argc, char *argv[])
 
    // Define the ODE solver used for time integration. Several explicit
    // Runge-Kutta methods are available.
-   ODESolver *ode_solver = NULL;
+   IDPODESolver *ode_solver = NULL;
    switch (ode_solver_type)
    {
-      case 1: ode_solver = new ForwardEulerSolver; break;
+      //case 1: ode_solver = new ForwardEulerSolver; break;
       case 2: ode_solver = new RK2IDPSolver(); break;
-      case 3: ode_solver = new RK3SSPSolver; break;
+      /*case 3: ode_solver = new RK3SSPSolver; break;
       case 4:
          if (myid == 0) { MFEM_WARNING("RK4 may violate the bounds."); }
          ode_solver = new RK4Solver; break;
       case 6:
          if (myid == 0) { MFEM_WARNING("RK6 may violate the bounds."); }
-         ode_solver = new RK6Solver; break;
+         ode_solver = new RK6Solver; break;*/
       default:
          cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          return 3;
@@ -1251,7 +1256,7 @@ AdvectionOperator::AdvectionOperator(int size, BilinearForm &Mbf_,
                                      LowOrderMethod &_lom, DofInfo &_dofs,
                                      HOSolver *hos, LOSolver *los, FCTSolver *fct,
                                      MonolithicSolver *mos) :
-   TimeDependentOperator(size), Mbf(Mbf_), ml(_ml), Kbf(Kbf_),
+   LimitedTimeDependentOperator(size), Mbf(Mbf_), ml(_ml), Kbf(Kbf_),
    M_HO(M_HO_), K_HO(K_HO_),
    lumpedM(_lumpedM),
    start_mesh_pos(pos.Size()), start_submesh_pos(sub_vel.Size()),

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -42,6 +42,7 @@
 #include "remhos_mono.hpp"
 #include "remhos_tools.hpp"
 #include "remhos_sync.hpp"
+#include "remhos_solvers.hpp"
 
 using namespace std;
 using namespace mfem;
@@ -77,16 +78,6 @@ double inflow_function(const Vector &x);
 
 // Mesh bounding box
 Vector bb_min, bb_max;
-
-class RK2IDPSolver : public ODESolver
-{
-   Vector dx12, dx;
-
-public:
-   RK2IDPSolver();
-   void Init(TimeDependentOperator &f) override;
-   void Step(Vector &x, double &t, double &dt) override;
-};
 
 class AdvectionOperator : public TimeDependentOperator
 {
@@ -1872,29 +1863,4 @@ double inflow_function(const Vector &x)
       return 0.25*(1.+tanh((r+c-a)/b))*(1.-tanh((r-c-a)/b));
    }
    else { return 0.0; }
-}
-
-RK2IDPSolver::RK2IDPSolver()
-{
-}
-
-void RK2IDPSolver::Init(TimeDependentOperator &f)
-{
-   ODESolver::Init(f);
-   dx12.SetSize(f.Height());
-   dx.SetSize(f.Height());
-}
-
-void RK2IDPSolver::Step(Vector &x, double &t, double &dt)
-{
-   f->SetTime(t);
-   f->Mult(x, dx12);
-
-   x.Add(dt/2., dx12);
-   f->SetTime(t+dt/2.);
-   f->Mult(x, dx);
-
-   add(2., dx, -1., dx12, dx);
-
-   x.Add(dt/2., dx);
 }

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -27,7 +27,11 @@
 // as part of the Eulerian phase in Arbitrary-Lagrangian Eulerian (ALE)
 // simulations.
 //
-// Sample runs: see README.md, section 'Verification of Results'.
+// single step:
+// mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 14 -rs 3 -dt 0.002 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 1 -vs 20
+// RK2:
+// mpirun -np 8 remhos -m ./data/inline-quad.mesh -p 14 -rs 3 -dt 0.002 -tf 0.75 -ho 3 -lo 1 -fct 1 -ps -s 2 -vs 20
+//
 
 #include "mfem.hpp"
 #include <fstream>
@@ -984,7 +988,7 @@ int main(int argc, char *argv[])
             if (active_dofs[i] == false) { continue; }
 
             double us_min = u(i) * s_min_glob;
-            if (us(i) < us_min) { us(i) = us_min; }
+            //if (us(i) < us_min) { us(i) = us_min; }
          }
 
 #ifdef REMHOS_FCT_PRODUCT_DEBUG

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -333,7 +333,7 @@ int main(int argc, char *argv[])
    if (ode_solver_type > 10)
    {
       auto rk_idp = dynamic_cast<RKIDPSolver *>(idp_ode_solver);
-      if (rk_idp) { rk_idp->UseMask(true); }
+      if (rk_idp) { rk_idp->UseMask(false); }
       ode_solver = idp_ode_solver;
    }
 
@@ -934,8 +934,7 @@ int main(int argc, char *argv[])
 
    double u_min, u_max;
    GetMinMax(u, u_min, u_max);
-   double s_min = numeric_limits<double>::infinity(),
-          s_max = -numeric_limits<double>::infinity();
+   double s_min = -1.0, s_max = -1.0;
    if (product_sync) { ComputeMinMaxS(NE, us, u, s_min, s_max); }
 
    if (exec_mode == 1)
@@ -1025,6 +1024,7 @@ int main(int argc, char *argv[])
       // Monotonicity check for debug purposes mainly.
       if (verify_bounds && forced_bounds && smth_indicator == NULL)
       {
+         const double eps = 1e-10;
          double u_min_new, u_max_new,
                 s_min_new = s_min, s_max_new = s_max;
          GetMinMax(u, u_min_new, u_max_new);
@@ -1037,13 +1037,13 @@ int main(int argc, char *argv[])
          {
             if (myid == 0)
             {
-               MFEM_VERIFY(u_min_new > u_min - 1e-12,
+               MFEM_VERIFY(u_min_new > u_min - eps,
                            "Undershoot of " << u_min - u_min_new);
-               MFEM_VERIFY(u_max_new < u_max + 1e-12,
+               MFEM_VERIFY(u_max_new < u_max + eps,
                            "Overshoot of " << u_max_new - u_max);
-               MFEM_VERIFY(s_min_new > s_min - 1e-12,
+               MFEM_VERIFY(s_min_new > s_min - eps,
                            "Undershoot in s of " << s_min - s_min_new);
-               MFEM_VERIFY(s_max_new < s_max + 1e-12,
+               MFEM_VERIFY(s_max_new < s_max + eps,
                            "Overshoot in s of " << s_max_new - s_max);
             }
             u_min = u_min_new;
@@ -1053,13 +1053,13 @@ int main(int argc, char *argv[])
          {
             if (myid == 0)
             {
-               MFEM_VERIFY(u_min_new > 0.0 - 1e-12,
+               MFEM_VERIFY(u_min_new > 0.0 - eps,
                            "Undershoot of " << 0.0 - u_min_new);
-               MFEM_VERIFY(u_max_new < 1.0 + 1e-12,
+               MFEM_VERIFY(u_max_new < 1.0 + eps,
                            "Overshoot of " << u_max_new - 1.0);
-               MFEM_VERIFY(s_min_new > 0.0 - 1e-12,
+               MFEM_VERIFY(s_min_new > 0.0 - eps,
                            "Undershoot in s of " << 0.0 - s_min_new);
-               MFEM_VERIFY(s_max_new < 1.0 + 1e-12,
+               MFEM_VERIFY(s_max_new < 1.0 + eps,
                            "Overshoot in s of " << s_max_new - 1.0);
             }
          }

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -122,6 +122,8 @@ public:
 
    void MultUnlimited(const Vector &x, Vector &y) const override;
 
+   void ComputeMask(const Vector &x, Array<bool> &mask) const override;
+
    void LimitMult(const Vector &x, Vector &y) const override;
 
    void SetTimeStepControl(TimeStepControl tsc)
@@ -1399,6 +1401,57 @@ void AdvectionOperator::MultUnlimited(const Vector &X, Vector &Y) const
 
       d_us.SyncAliasMemory(Y);
    }
+}
+
+void AdvectionOperator::ComputeMask(const Vector &x, Array<bool> &mask) const
+{
+   const int NE = Mbf.FESpace()->GetNE();
+   Array<bool> bool_els;
+
+   if (block_offsets.Size() <= 2)
+   {
+      // Only product fields must be masked
+      mask.SetSize(x.Size());
+      mask = true;
+      return;
+   }
+
+   const BlockVector bx(const_cast<Vector&>(x), block_offsets);
+   Array<bool> bool_dofs;
+   ComputeBoolIndicators(NE, bx.GetBlock(0), bool_els, bool_dofs);
+
+   // All DOFs must be active for consistency of update
+   const int ndof_el = bx.GetBlock(0).Size() / NE;
+   for (int k = 0; k < NE; k++)
+   {
+      if (!bool_els[k]) { continue; }
+
+      bool dofs_active = true;
+      for (int j = 0; j < ndof_el; j++)
+      {
+         if (!bool_dofs[j+ndof_el*k])
+         {
+            dofs_active = false;
+            break;
+         }
+      }
+
+      if (!dofs_active)
+         for (int j = 0; j < ndof_el; j++)
+         {
+            bool_dofs[j+ndof_el*k] = false;
+         }
+   }
+
+   // Apply the u mask to all product fields
+   const int ndofs = bool_dofs.Size();
+   const int ndim = block_offsets.Size() - 1;
+   mask.SetSize(ndofs * ndim);
+   for (int i = 0; i < ndofs; i++)
+      for (int d = 0; d < ndim; d++)
+      {
+         mask[i+ndofs*d] = bool_dofs[i];
+      }
 }
 
 void AdvectionOperator::LimitMult(const Vector &X, Vector &Y) const

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -299,7 +299,7 @@ int main(int argc, char *argv[])
    IDPODESolver *ode_solver = NULL;
    switch (ode_solver_type)
    {
-      //case 1: ode_solver = new ForwardEulerSolver; break;
+      case 1: ode_solver = new ForwardEulerIDPSolver(); break;
       case 2: ode_solver = new RK2IDPSolver(); break;
       /*case 3: ode_solver = new RK3SSPSolver; break;
       case 4:

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -1436,10 +1436,12 @@ void AdvectionOperator::ComputeMask(const Vector &x, Array<bool> &mask) const
       }
 
       if (!dofs_active)
+      {
          for (int j = 0; j < ndof_el; j++)
          {
             bool_dofs[j+ndof_el*k] = false;
          }
+      }
    }
 
    // Apply the u mask to all product fields
@@ -1447,10 +1449,12 @@ void AdvectionOperator::ComputeMask(const Vector &x, Array<bool> &mask) const
    const int ndim = block_offsets.Size() - 1;
    mask.SetSize(ndofs * ndim);
    for (int i = 0; i < ndofs; i++)
+   {
       for (int d = 0; d < ndim; d++)
       {
          mask[i+ndofs*d] = bool_dofs[i];
       }
+   }
 }
 
 void AdvectionOperator::LimitMult(const Vector &X, Vector &Y) const
@@ -1462,7 +1466,6 @@ void AdvectionOperator::LimitMult(const Vector &X, Vector &Y) const
    BlockVector block_Y(Y, block_offsets);
    const Vector &u = block_X.GetBlock(0);
    Vector &d_u = block_Y.GetBlock(0);
-
 
    if (fct_solver)
    {

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -48,9 +48,11 @@ using namespace mfem;
 
 enum class HOSolverType {None, Neumann, CG, LocalInverse};
 enum class FCTSolverType {None, FluxBased, ClipScale,
-                          NonlinearPenalty, FCTProject};
+                          NonlinearPenalty, FCTProject
+                         };
 enum class LOSolverType {None,    DiscrUpwind,    DiscrUpwindPrec,
-                         ResDist, ResDistSubcell, MassBased};
+                         ResDist, ResDistSubcell, MassBased
+                        };
 enum class MonolithicSolverType {None, ResDistMono, ResDistMonoSubcell};
 
 enum class TimeStepControl {FixedTimeStep, LOBoundsError};

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -309,11 +309,9 @@ int main(int argc, char *argv[])
    {
       case 1: ode_solver = new ForwardEulerIDPSolver(); break;
       case 2: ode_solver = new RK2IDPSolver(); break;
-      /*case 3: ode_solver = new RK3SSPSolver; break;
-      case 4:
-         if (myid == 0) { MFEM_WARNING("RK4 may violate the bounds."); }
-         ode_solver = new RK4Solver; break;
-      case 6:
+      case 3: ode_solver = new RK3IDPSolver(); break;
+      case 4: ode_solver = new RK4IDPSolver(); break;
+      /*case 6:
          if (myid == 0) { MFEM_WARNING("RK6 may violate the bounds."); }
          ode_solver = new RK6Solver; break;*/
       default:

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -94,7 +94,6 @@ private:
 
    mutable ParGridFunction x_gf;
 
-   double dt;
    TimeStepControl dt_control;
    mutable double dt_est;
    Assembly &asmbl;
@@ -137,7 +136,9 @@ public:
       }
       dt_control = tsc;
    }
-   void SetDt(double _dt) { dt = _dt; dt_est = dt; }
+
+   void SetDt(double _dt) override { LimitedTimeDependentOperator::SetDt(_dt); dt_est = dt; }
+
    double GetTimeStepEstimate() { return dt_est; }
 
    void SetRemapStartPos(const Vector &m_pos, const Vector &sm_pos)

--- a/remhos_fct.cpp
+++ b/remhos_fct.cpp
@@ -276,19 +276,6 @@ void FluxBasedFCT::CalcFCTProduct(const ParGridFunction &us, const Vector &m,
             dof_id = k*ndofs + j;
             if (active_dofs[dof_id] == false) { continue; }
 
-            double s = us_new(dof_id) / u_new(dof_id);
-            if (s + eps < s_min(dof_id) ||
-                s - eps > s_max(dof_id))
-            {
-               std::cout << "Final s " << j << " " << k << " "
-                         << s_min(dof_id) << " "
-                         << s << " "
-                         << s_max(dof_id) << std::endl;
-               std::cout << "---\n";
-
-               MFEM_ABORT("s not in bounds after FCT.");
-            }
-
             if (us_new(dof_id) + eps < us_min(dof_id) ||
                 us_new(dof_id) - eps > us_max(dof_id))
             {

--- a/remhos_fct.cpp
+++ b/remhos_fct.cpp
@@ -745,12 +745,13 @@ void ElementFCTProjection::CalcFCTSolution(const ParGridFunction &u,
    } // element loop
 }
 
-void ElementFCTProjection::CalcFCTProduct(const ParGridFunction &us, const Vector &m,
-                                     const Vector &d_us_HO, const Vector &d_us_LO,
-                                     Vector &s_min, Vector &s_max,
-                                     const Vector &u_new,
-                                     const Array<bool> &active_el,
-                                     const Array<bool> &active_dofs, Vector &d_us)
+void ElementFCTProjection::CalcFCTProduct(const ParGridFunction &us,
+                                          const Vector &m,
+                                          const Vector &d_us_HO, const Vector &d_us_LO,
+                                          Vector &s_min, Vector &s_max,
+                                          const Vector &u_new,
+                                          const Array<bool> &active_el,
+                                          const Array<bool> &active_dofs, Vector &d_us)
 {
    us.HostRead();
    s_min.HostReadWrite();

--- a/remhos_fct.cpp
+++ b/remhos_fct.cpp
@@ -115,32 +115,6 @@ void FCTSolver::CalcCompatibleLOProduct(const ParGridFunction &us,
          dof_id = k*ndofs + j;
          d_us_LO_new(dof_id) = (u_new(dof_id) * s_avg - us(dof_id)) / dt;
       }
-
-#ifdef REMHOS_FCT_PRODUCT_DEBUG
-      // Check the LO product solution.
-      double us_min, us_max;
-      for (int j = 0; j < ndofs; j++)
-      {
-         dof_id = k*ndofs + j;
-         if (active_dofs[dof_id] == false) { continue; }
-
-         us_min = s_min_loc(j) * u_new(dof_id);
-         us_max = s_max_loc(j) * u_new(dof_id);
-
-         if (s_avg * u_new(dof_id) + eps < us_min ||
-             s_avg * u_new(dof_id) - eps > us_max)
-         {
-            std::cout << "---\ns_avg * u: " << k << " "
-                      << us_min << " "
-                      << s_avg * u_new(dof_id) << " "
-                      << us_max << endl
-                      << u_new(dof_id) << " " << s_avg << endl
-                      << s_min_loc(j) << " " << s_max_loc(j) << "\n---\n";
-
-            MFEM_ABORT("s_avg * u not in bounds");
-         }
-      }
-#endif
    }
 }
 
@@ -287,43 +261,48 @@ void FluxBasedFCT::CalcFCTProduct(const ParGridFunction &us, const Vector &m,
       dus_lo_fct = d_us;
    }
 
-#ifdef REMHOS_FCT_PRODUCT_DEBUG
-   // Check the bounds of the final solution.
-   const double eps = 1e-12;
-   Vector us_new(d_us.Size());
-   add(1.0, us, dt, d_us, us_new);
-   for (int k = 0; k < NE; k++)
+   if (verify_bounds)
    {
-      if (active_el[k] == false) { continue; }
-
-      for (int j = 0; j < ndofs; j++)
+      // Check the bounds of the final solution.
+      const double eps = 1e-12;
+      Vector us_new(d_us.Size());
+      add(1.0, us, dt, d_us, us_new);
+      for (int k = 0; k < NE; k++)
       {
-         dof_id = k*ndofs + j;
-         if (active_dofs[dof_id] == false) { continue; }
+         if (active_el[k] == false) { continue; }
 
-         double s = us_new(dof_id) / u_new(dof_id);
-         if (s + eps < s_min(dof_id) ||
-             s - eps > s_max(dof_id))
+         for (int j = 0; j < ndofs; j++)
          {
-            std::cout << "Final s " << j << " " << k << " "
-                      << s_min(dof_id) << " "
-                      << s << " "
-                      << s_max(dof_id) << std::endl;
-            std::cout << "---\n";
-         }
+            dof_id = k*ndofs + j;
+            if (active_dofs[dof_id] == false) { continue; }
 
-         if (us_new(dof_id) + eps < us_min(dof_id) ||
-             us_new(dof_id) - eps > us_max(dof_id))
-         {
-            std::cout << "Final us " << j << " " << k << " "
-                      << us_min(dof_id) << " "
-                      << us_new(dof_id) << " "
-                      << us_max(dof_id) << std::endl;
-            std::cout << "---\n";
+            double s = us_new(dof_id) / u_new(dof_id);
+            if (s + eps < s_min(dof_id) ||
+                s - eps > s_max(dof_id))
+            {
+               std::cout << "Final s " << j << " " << k << " "
+                         << s_min(dof_id) << " "
+                         << s << " "
+                         << s_max(dof_id) << std::endl;
+               std::cout << "---\n";
+
+               MFEM_ABORT("s not in bounds after FCT.");
+            }
+
+            if (us_new(dof_id) + eps < us_min(dof_id) ||
+                us_new(dof_id) - eps > us_max(dof_id))
+            {
+               std::cout << "Final us " << j << " " << k << " "
+                         << us_min(dof_id) << " "
+                         << us_new(dof_id) << " "
+                         << us_max(dof_id) << std::endl;
+               std::cout << "---\n";
+
+               MFEM_ABORT("us not in bounds after FCT.");
+            }
          }
       }
    }
-#endif
 }
 
 void FluxBasedFCT::ComputeFluxMatrix(const ParGridFunction &u,

--- a/remhos_fct.hpp
+++ b/remhos_fct.hpp
@@ -32,7 +32,7 @@ class FCTSolver
 protected:
    ParFiniteElementSpace &pfes;
    SmoothnessIndicator *smth_indicator;
-   double dt;
+   real_t dt;
    const bool needs_LO_input_for_products;
 
    // Computes a compatible slope (piecewise constan = mass_us / mass_u).
@@ -51,13 +51,13 @@ protected:
 
 public:
    FCTSolver(ParFiniteElementSpace &space,
-             SmoothnessIndicator *si, double dt_, bool needs_LO_prod)
+             SmoothnessIndicator *si, real_t dt_, bool needs_LO_prod)
       : pfes(space), smth_indicator(si), dt(dt_),
         needs_LO_input_for_products(needs_LO_prod) { }
 
    virtual ~FCTSolver() { }
 
-   virtual void UpdateTimeStep(double dt_new) { dt = dt_new; }
+   virtual void UpdateTimeStep(real_t dt_new) { dt = dt_new; }
 
    bool NeedsLOProductInput() const { return needs_LO_input_for_products; }
 
@@ -110,7 +110,7 @@ protected:
 
 public:
    FluxBasedFCT(ParFiniteElementSpace &space,
-                SmoothnessIndicator *si, double delta_t,
+                SmoothnessIndicator *si, real_t delta_t,
                 const SparseMatrix &adv_mat, const Array<int> &adv_smap,
                 const SparseMatrix &mass_mat, int fct_iterations = 1)
       : FCTSolver(space, si, delta_t, true),
@@ -134,7 +134,7 @@ class ClipScaleSolver : public FCTSolver
 {
 public:
    ClipScaleSolver(ParFiniteElementSpace &space,
-                   SmoothnessIndicator *si, double dt)
+                   SmoothnessIndicator *si, real_t dt)
       : FCTSolver(space, si, dt, false) { }
 
    virtual void CalcFCTSolution(const ParGridFunction &u, const Vector &m,
@@ -153,7 +153,7 @@ public:
 class ElementFCTProjection : public FCTSolver
 {
 public:
-   ElementFCTProjection(ParFiniteElementSpace &space, double dt)
+   ElementFCTProjection(ParFiniteElementSpace &space, real_t dt)
       : FCTSolver(space, NULL, dt, false) { }
 
    virtual void CalcFCTSolution(const ParGridFunction &u, const Vector &m,
@@ -178,7 +178,7 @@ protected:
 
 public:
    NonlinearPenaltySolver(ParFiniteElementSpace &space,
-                          SmoothnessIndicator *si, double dt_)
+                          SmoothnessIndicator *si, real_t dt_)
       : FCTSolver(space, si, dt_, false) { }
 
    virtual void CalcFCTSolution(const ParGridFunction &u, const Vector &m,

--- a/remhos_fct.hpp
+++ b/remhos_fct.hpp
@@ -17,7 +17,7 @@
 #ifndef MFEM_REMHOS_FCT
 #define MFEM_REMHOS_FCT
 
-#define REMHOS_FCT_PRODUCT_DEBUG
+//#define REMHOS_FCT_PRODUCT_DEBUG
 
 #include "mfem.hpp"
 

--- a/remhos_fct.hpp
+++ b/remhos_fct.hpp
@@ -17,7 +17,7 @@
 #ifndef MFEM_REMHOS_FCT
 #define MFEM_REMHOS_FCT
 
-//#define REMHOS_FCT_PRODUCT_DEBUG
+#define REMHOS_FCT_PRODUCT_DEBUG
 
 #include "mfem.hpp"
 
@@ -83,6 +83,8 @@ public:
    {
       MFEM_ABORT("Product remap is not implemented for the chosen solver");
    }
+
+   bool verify_bounds = false;
 };
 
 class FluxBasedFCT : public FCTSolver

--- a/remhos_lo.cpp
+++ b/remhos_lo.cpp
@@ -247,25 +247,24 @@ void ResidualDistribution::CalcLOSolution(const Vector &u, Vector &du) const
 void MassBasedAvg::CalcLOSolution(const Vector &u, Vector &du) const
 {
    // Compute the new HO solution.
-   Vector du_HO(u.Size());
    ParGridFunction u_HO_new(&pfes);
-   ho_solver.CalcHOSolution(u, du_HO);
-   add(1.0, u, dt, du_HO, u_HO_new);
-
-   // Mesh positions for the new HO solution.
-   ParMesh *pmesh = pfes.GetParMesh();
-   GridFunction x_new(pmesh->GetNodes()->FESpace());
-   // Copy the current nodes into x.
-   pmesh->GetNodes(x_new);
-   if (mesh_v)
+   if (du_HO)
    {
-      // Remap mode - get the positions of the mesh at time [t + dt].
-      x_new.Add(dt, *mesh_v);
+      add(1.0, u, dt, *du_HO, u_HO_new);
+      du_HO = nullptr;
+   }
+   else
+   {
+      Vector du_HO(u.Size());
+      ho_solver.CalcHOSolution(u, du_HO);
+      add(1.0, u, dt, du_HO, u_HO_new);
    }
 
+   // Mesh positions.
+   ParMesh *pmesh = pfes.GetParMesh();
    const int NE = pfes.GetNE();
    Vector el_mass(NE), el_vol(NE);
-   MassesAndVolumesAtPosition(u_HO_new, x_new, el_mass, el_vol);
+   MassesAndVolumesAtPosition(u_HO_new, *pmesh->GetNodes(), el_mass, el_vol);
 
    const int ndofs = u.Size() / NE;
    for (int k = 0; k < NE; k++)

--- a/remhos_lo.hpp
+++ b/remhos_lo.hpp
@@ -27,14 +27,14 @@ class LOSolver
 {
 protected:
    ParFiniteElementSpace &pfes;
-   double dt = -1.0; // usually not known at creation, updated later.
+   real_t dt = -1.0; // usually not known at creation, updated later.
 
 public:
    LOSolver(ParFiniteElementSpace &space) : pfes(space) { }
 
    virtual ~LOSolver() { }
 
-   virtual void UpdateTimeStep(double dt_new) { dt = dt_new; }
+   virtual void UpdateTimeStep(real_t dt_new) { dt = dt_new; }
 
    virtual void CalcLOSolution(const Vector &u, Vector &du) const = 0;
 };

--- a/remhos_lo.hpp
+++ b/remhos_lo.hpp
@@ -86,6 +86,9 @@ protected:
    HOSolver &ho_solver;
    const GridFunction *mesh_v;
 
+   // Temporary HO solution, used only in the next call to CalcLOSolution().
+   mutable const Vector *du_HO = nullptr;
+
    void MassesAndVolumesAtPosition(const ParGridFunction &u,
                                    const GridFunction &x,
                                    Vector &el_mass, Vector &el_vol) const;
@@ -94,6 +97,9 @@ public:
    MassBasedAvg(ParFiniteElementSpace &space, HOSolver &hos,
                 const GridFunction *mesh_vel)
       : LOSolver(space), ho_solver(hos), mesh_v(mesh_vel) { }
+
+   // Temporary HO solution, used only in the next call to CalcLOSolution().
+   void SetHOSolution(Vector &du) { du_HO = &du; }
 
    virtual void CalcLOSolution(const Vector &u, Vector &du) const;
 };

--- a/remhos_lo.hpp
+++ b/remhos_lo.hpp
@@ -91,11 +91,11 @@ protected:
                                    Vector &el_mass, Vector &el_vol) const;
 
 public:
-  MassBasedAvg(ParFiniteElementSpace &space, HOSolver &hos,
-               const GridFunction *mesh_vel)
-     : LOSolver(space), ho_solver(hos), mesh_v(mesh_vel) { }
+   MassBasedAvg(ParFiniteElementSpace &space, HOSolver &hos,
+                const GridFunction *mesh_vel)
+      : LOSolver(space), ho_solver(hos), mesh_v(mesh_vel) { }
 
-  virtual void CalcLOSolution(const Vector &u, Vector &du) const;
+   virtual void CalcLOSolution(const Vector &u, Vector &du) const;
 };
 
 //PA based Residual Distribution

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#include "remhos_solvers.hpp"
+
+namespace mfem
+{
+
+RK2IDPSolver::RK2IDPSolver()
+{
+}
+
+void RK2IDPSolver::Init(TimeDependentOperator &f)
+{
+   ODESolver::Init(f);
+   dx12.SetSize(f.Height());
+   dx.SetSize(f.Height());
+}
+
+void RK2IDPSolver::Step(Vector &x, double &t, double &dt)
+{
+   f->SetTime(t);
+   f->Mult(x, dx12);
+
+   x.Add(dt/2., dx12);
+   f->SetTime(t+dt/2.);
+   f->Mult(x, dx);
+
+   add(2., dx, -1., dx12, dx);
+
+   x.Add(dt/2., dx);
+}
+
+} // namespace mfem

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -212,13 +212,19 @@ void RKIDPSolver::Step(Vector &x, double &t, double &dt)
       // Update mask with the HO update
       UpdateMask(x, dxs[i], dct, mask);
 
-      // Convert the HO update to Forward Euler
+      // Form the unlimited update for the stage.
+      // Note that it converts eq. (2.16) in JLG's paper into an update using
+      // the previous limited updates.
       if (d_i[i] != 1.)
       {
+         // for mask = 0, we get dxs (nothing happens).
+         //               the loop below won't change it -> Forward Euler.
+         // for mask = 1, we scale dxs by d_i[i].
          AddMasked(mask, d_i[i]-1., dxs[i], dxs[i]);
       }
       for (int j = 0; j < i; j++)
       {
+         // Use all previous limited updates.
          AddMasked(mask, d_i[j], dxs[j], dxs[i]);
       }
 

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -19,8 +19,21 @@
 namespace mfem
 {
 
-RK2IDPSolver::RK2IDPSolver()
+void ForwardEulerIDPSolver::Init(LimitedTimeDependentOperator &f)
 {
+   IDPODESolver::Init(f);
+   dx.SetSize(f.Height());
+}
+
+void ForwardEulerIDPSolver::Step(Vector &x, double &t, double &dt)
+{
+   f->SetTime(t);
+   f->SetDt(dt);
+   f->MultUnlimited(x, dx);
+   f->LimitMult(x, dx);
+
+   x.Add(dt, dx);
+   t += dt;
 }
 
 void RK2IDPSolver::Init(LimitedTimeDependentOperator &f)

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -212,10 +212,11 @@ void RKIDPSolver::Step(Vector &x, double &t, double &dt)
       // Update mask with the HO update
       if (use_masks) { UpdateMask(x, dxs[i], dct, mask); }
 
+      //
       // Form the unlimited update for the stage.
       // Note that it converts eq. (2.16) in JLG's paper into an update using
       // the previous limited updates.
-      if (d_i[i] != 1.)
+      //
       {
          // for mask = 0, we get dxs (nothing happens).
          //               the loop below won't change it -> Forward Euler.
@@ -223,14 +224,14 @@ void RKIDPSolver::Step(Vector &x, double &t, double &dt)
          if (use_masks) { AddMasked(mask, d_i[i]-1., dxs[i], dxs[i]); }
          else           { dxs[i] *= d_i[i]; }
       }
+      // Use all previous limited updates.
       for (int j = 0; j < i; j++)
       {
-         // Use all previous limited updates.
          if (use_masks) { AddMasked(mask, d_i[j], dxs[j], dxs[i]); }
          else           { dxs[i].Add(d_i[j], dxs[j]); }
       }
 
-      // Limit the step
+      // Limit the step (always a Forward Euler step).
       f->LimitMult(x, dxs[i]);
 
       // Update the state

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -42,6 +42,7 @@ void RK2IDPSolver::Step(Vector &x, double &t, double &dt)
    add(2., dx, -1., dx12, dx);
 
    x.Add(dt/2., dx);
+   t += dt;
 }
 
 } // namespace mfem

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -33,10 +33,12 @@ void RK2IDPSolver::Init(LimitedTimeDependentOperator &f)
 void RK2IDPSolver::Step(Vector &x, double &t, double &dt)
 {
    f->SetTime(t);
+   f->SetDt(dt/2.);
    f->Mult(x, dx12);
 
    x.Add(dt/2., dx12);
    f->SetTime(t+dt/2.);
+   //f->SetDt(dt/2.);
    f->Mult(x, dx);
 
    add(2., dx, -1., dx12, dx);

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -23,9 +23,9 @@ RK2IDPSolver::RK2IDPSolver()
 {
 }
 
-void RK2IDPSolver::Init(TimeDependentOperator &f)
+void RK2IDPSolver::Init(LimitedTimeDependentOperator &f)
 {
-   ODESolver::Init(f);
+   IDPODESolver::Init(f);
    dx12.SetSize(f.Height());
    dx.SetSize(f.Height());
 }

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -34,14 +34,16 @@ void RK2IDPSolver::Step(Vector &x, double &t, double &dt)
 {
    f->SetTime(t);
    f->SetDt(dt/2.);
-   f->Mult(x, dx12);
+   f->MultUnlimited(x, dx12);
+   f->LimitMult(x, dx12);
 
    x.Add(dt/2., dx12);
    f->SetTime(t+dt/2.);
    //f->SetDt(dt/2.);
-   f->Mult(x, dx);
+   f->MultUnlimited(x, dx);
 
    add(2., dx, -1., dx12, dx);
+   f->LimitMult(x, dx);
 
    x.Add(dt/2., dx);
    t += dt;

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -20,41 +20,105 @@
 namespace mfem
 {
 
-void IDPODESolver::AddMasked(const Array<bool> &mask, real_t a,
-                             const Vector &va,
-                             real_t b, const Vector &vb, Vector &vc)
+void ForwardEulerIDPSolver::Init(LimitedTimeDependentOperator &f)
 {
-   MFEM_ASSERT(va.Size() == vb.Size() && va.Size() == vc.Size(),
+   IDPODESolver::Init(f);
+   dx.SetSize(f.Height());
+}
+
+void ForwardEulerIDPSolver::Step(Vector &x, double &t, double &dt)
+{
+   f->SetTime(t);
+   f->SetDt(dt);
+   f->MultUnlimited(x, dx);
+   f->LimitMult(x, dx);
+
+   x.Add(dt, dx);
+   t += dt;
+}
+
+void RKIDPSolver::ConstructD()
+{
+   // Convert high-order to Forward Euler factors
+   d = new real_t[s*(s+1)/2];
+
+   const real_t *a_n = a;
+   const real_t *a_o = a;
+   int i_o = -1;
+   real_t c_o = 0.;
+
+   for (int i = 0; i < s; i++)
+   {
+      const real_t c_n = (i<s-1)?(c[i]):(1.);
+      const real_t dc = c_n - c_o;
+      real_t *di = d + i*(i+1)/2;
+
+      for (int j = 0; j < i; j++)
+      {
+         const real_t a_oj = (j<=i_o)?(a_o[j]):(0.);
+         const real_t m = (a_n[j] - a_oj) / dc;
+         if (m == 0.)
+         {
+            di[j] = 0.;
+            continue;
+         }
+         const real_t *dj = d + j*(j+1)/2;
+         const real_t dij = m / dj[j];
+         for (int k = 0; k < j; k++)
+         {
+            di[k] -= dj[k] * dij;
+         }
+         di[j] = dij;
+      }
+      di[i] = a_n[i] / dc;
+
+      i_o = i;
+      c_o = c_n;
+      a_o = a_n;
+
+      if (i < s-2)
+      {
+         a_n += i+1;
+      }
+      else
+      {
+         a_n = b;
+      }
+   }
+}
+
+void RKIDPSolver::AddMasked(const Array<bool> &mask, real_t b, const Vector &vb,
+                            Vector &va)
+{
+   MFEM_ASSERT(va.Size() == vb.Size(),
                "incompatible Vectors!");
 
 #if !defined(MFEM_USE_LEGACY_OPENMP)
-   const bool use_dev = va.UseDevice() || va.UseDevice() || vc.UseDevice();
-   const int N = vc.Size();
+   const bool use_dev = va.UseDevice() || va.UseDevice();
+   const int N = va.Size();
    // Note: get read access first, in case c is the same as a/b.
-   auto ad = va.Read(use_dev);
+   auto ad = va.ReadWrite(use_dev);
    auto bd = vb.Read(use_dev);
-   auto cd = vc.Write(use_dev);
    auto maskd = mask.Read(use_dev);
    mfem::forall_switch(use_dev, N, [=] MFEM_HOST_DEVICE (int i)
    {
-      cd[i] = (maskd[i])?(a * ad[i] + b * bd[i]):(cd[i]);
+      ad[i] += (maskd[i])?(b * bd[i]):(0.);
    });
 #else
-   const real_t *ap = va.GetData();
+   real_t *ap = va.GetData();
    const real_t *bp = vb.GetData();
-   real_t       *cp = vc.GetData();
    const bool   *maskp = mask.GetData();
-   const int      s = vc.Size();
+   const int      s = va.Size();
    #pragma omp parallel for
    for (int i = 0; i < s; i++)
    {
-      cp[i] = (maskp[i])?(a * ap[i] + b * bp[i]):(cp[i]);
+      ap[i] += (maskp[i])?(b * bp[i]):(0.);
    }
 #endif
 }
 
-void IDPODESolver::UpdateMask(const Vector &x, const Vector &dx, real_t dt,
-                              Array<bool> &mask)
+void RKIDPSolver::UpdateMask(const Vector &x, const Vector &dx, real_t dt,
+                             Array<bool> &mask)
 {
    Array<bool> mask_new(mask.Size());
    if (dt != 0.)
@@ -73,49 +137,82 @@ void IDPODESolver::UpdateMask(const Vector &x, const Vector &dx, real_t dt,
    }
 }
 
-void ForwardEulerIDPSolver::Init(LimitedTimeDependentOperator &f)
+RKIDPSolver::RKIDPSolver(int s_, const real_t a_[], const real_t b_[],
+                         const real_t c_[])
+   : s(s_), a(a_), b(b_), c(c_)
 {
-   IDPODESolver::Init(f);
-   dx.SetSize(f.Height());
+   dxs = new Vector[s];
+   ConstructD();
 }
 
-void ForwardEulerIDPSolver::Step(Vector &x, double &t, double &dt)
+RKIDPSolver::~RKIDPSolver()
 {
+   delete[] dxs;
+}
+
+void RKIDPSolver::Init(LimitedTimeDependentOperator &f_)
+{
+   IDPODESolver::Init(f_);
+   for (int i = 0; i < s; i++)
+   {
+      dxs[i].SetSize(f->Height());
+   }
+}
+
+void RKIDPSolver::Step(Vector &x, double &t, double &dt)
+{
+   // Perform the first step
    f->SetTime(t);
-   f->SetDt(dt);
-   f->MultUnlimited(x, dx);
-   f->LimitMult(x, dx);
+   f->SetDt(c[0] * dt);
+   f->MultUnlimited(x, dxs[0]);
+   f->LimitMult(x, dxs[0]);
 
-   x.Add(dt, dx);
-   t += dt;
-}
-
-void RK2IDPSolver::Init(LimitedTimeDependentOperator &f)
-{
-   IDPODESolver::Init(f);
-   dx12.SetSize(f.Height());
-   dx.SetSize(f.Height());
-}
-
-void RK2IDPSolver::Step(Vector &x, double &t, double &dt)
-{
-   f->SetTime(t);
-   f->SetDt(dt/2.);
-   f->MultUnlimited(x, dx12);
-   f->LimitMult(x, dx12);
-
-   x.Add(dt/2., dx12);
+   x.Add(c[0] * dt, dxs[0]);
    f->ComputeMask(x, mask);
-   f->SetTime(t+dt/2.);
-   //f->SetDt(dt/2.);
-   f->MultUnlimited(x, dx);
+   f->SetTime(c[0] * dt);
 
-   UpdateMask(x, dx, dt/2., mask);
-   AddMasked(mask, 2., dx, -1., dx12, dx);
-   f->LimitMult(x, dx);
+   // Step through higher stages
 
-   x.Add(dt/2., dx);
+   const real_t *d_i = d + 1;
+
+   for (int i = 1; i < s; i++)
+   {
+      const real_t c_o = c[i-1];
+      const real_t c_n = (i<s-1)?(c[i]):(1.);
+      const real_t dc = c_n - c_o;
+      const real_t dct = dc * dt;
+
+      // Explicit HO step
+      f->SetDt(dct);
+      f->MultUnlimited(x, dxs[i]);
+
+      // Update mask with the HO update
+      UpdateMask(x, dxs[i], dct, mask);
+
+      // Convert the HO update to Forward Euler
+      if (d_i[i] != 1.)
+      {
+         AddMasked(mask, d_i[i]-1., dxs[i], dxs[i]);
+      }
+      for (int j = 0; j < i; j++)
+      {
+         AddMasked(mask, d_i[j], dxs[j], dxs[i]);
+      }
+
+      // Limit the step
+      f->LimitMult(x, dxs[i]);
+
+      // Update the state
+      f->SetTime(t + c_n * dt);
+      x.Add(dct, dxs[i]);
+      d_i += i+1;
+   }
+
    t += dt;
 }
+
+const real_t RK2IDPSolver::a[] = {.5};
+const real_t RK2IDPSolver::b[] = {0., 1.};
+const real_t RK2IDPSolver::c[] = {.5};
 
 } // namespace mfem

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -184,7 +184,7 @@ void RKIDPSolver::Step(Vector &x, double &t, double &dt)
    {
       x.Add(c[0] * dt, dxs[0]);
       f->ComputeMask(x, mask);
-      f->SetTime(c[0] * dt);
+      f->SetTime(t + c[0] * dt);
       c_o = c[0];
    }
    else

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -211,8 +211,19 @@ void RKIDPSolver::Step(Vector &x, double &t, double &dt)
    t += dt;
 }
 
+//2nd order
 const real_t RK2IDPSolver::a[] = {.5};
 const real_t RK2IDPSolver::b[] = {0., 1.};
 const real_t RK2IDPSolver::c[] = {.5};
+
+//3rd order
+const real_t RK3IDPSolver::a[] = {1./3., 0., 2./3.};
+const real_t RK3IDPSolver::b[] = {.25, 0., .75};
+const real_t RK3IDPSolver::c[] = {1./3., 2./3.};
+
+//4th order for linear, 3rd for non-linear
+const real_t RK4IDPSolver::a[] = {.25, 0., .5, 0., .25, .5};
+const real_t RK4IDPSolver::b[] = {0., 2./3., -1./3., 2./3.};
+const real_t RK4IDPSolver::c[] = {.25, .5, .75};
 
 } // namespace mfem

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -15,9 +15,63 @@
 // testbed platforms, in support of the nation's exascale computing imperative.
 
 #include "remhos_solvers.hpp"
+#include "general/forall.hpp"
 
 namespace mfem
 {
+
+void IDPODESolver::AddMasked(const Array<bool> &mask, real_t a,
+                             const Vector &va,
+                             real_t b, const Vector &vb, Vector &vc)
+{
+   MFEM_ASSERT(va.Size() == vb.Size() && va.Size() == vc.Size(),
+               "incompatible Vectors!");
+
+#if !defined(MFEM_USE_LEGACY_OPENMP)
+   const bool use_dev = va.UseDevice() || va.UseDevice() || vc.UseDevice();
+   const int N = vc.Size();
+   // Note: get read access first, in case c is the same as a/b.
+   auto ad = va.Read(use_dev);
+   auto bd = vb.Read(use_dev);
+   auto cd = vc.Write(use_dev);
+   auto maskd = mask.Read(use_dev);
+   mfem::forall_switch(use_dev, N, [=] MFEM_HOST_DEVICE (int i)
+   {
+      cd[i] = (maskd[i])?(a * ad[i] + b * bd[i]):(cd[i]);
+   });
+#else
+   const real_t *ap = va.GetData();
+   const real_t *bp = vb.GetData();
+   real_t       *cp = vc.GetData();
+   const bool   *maskp = mask.GetData();
+   const int      s = vc.Size();
+   #pragma omp parallel for
+   for (int i = 0; i < s; i++)
+   {
+      cp[i] = (maskp[i])?(a * ap[i] + b * bp[i]):(cp[i]);
+   }
+#endif
+}
+
+void IDPODESolver::UpdateMask(const Vector &x, const Vector &dx, real_t dt,
+                              Array<bool> &mask)
+{
+   Array<bool> mask_new(mask.Size());
+   if (dt != 0.)
+   {
+      Vector x_new(x.Size());
+      add(x, dt, dx, x_new);
+      f->ComputeMask(x_new, mask_new);
+   }
+   else
+   {
+      f->ComputeMask(x, mask_new);
+   }
+   for (int i = 0; i < mask.Size(); i++)
+   {
+      mask[i] = mask[i] && mask_new[i];
+   }
+}
 
 void ForwardEulerIDPSolver::Init(LimitedTimeDependentOperator &f)
 {
@@ -51,11 +105,13 @@ void RK2IDPSolver::Step(Vector &x, double &t, double &dt)
    f->LimitMult(x, dx12);
 
    x.Add(dt/2., dx12);
+   f->ComputeMask(x, mask);
    f->SetTime(t+dt/2.);
    //f->SetDt(dt/2.);
    f->MultUnlimited(x, dx);
 
-   add(2., dx, -1., dx12, dx);
+   UpdateMask(x, dx, dt/2., mask);
+   AddMasked(mask, 2., dx, -1., dx12, dx);
    f->LimitMult(x, dx);
 
    x.Add(dt/2., dx);

--- a/remhos_solvers.cpp
+++ b/remhos_solvers.cpp
@@ -194,6 +194,7 @@ void RKIDPSolver::Step(Vector &x, double &t, double &dt)
       add(x, c[0] * dt, dxs[0], x_new);
       f->ComputeMask(x_new, mask);
    }
+   //mask = 1;
 
    // Step through higher stages
 
@@ -211,6 +212,7 @@ void RKIDPSolver::Step(Vector &x, double &t, double &dt)
 
       // Update mask with the HO update
       UpdateMask(x, dxs[i], dct, mask);
+      //mask = 1;
 
       // Form the unlimited update for the stage.
       // Note that it converts eq. (2.16) in JLG's paper into an update using

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -97,6 +97,7 @@ class RKIDPSolver : public IDPODESolver
    const real_t *a, *b, *c;
    real_t *d;
    Vector *dxs;
+   bool use_masks = false;
    Array<bool> mask;
 
    // This function constructs coefficients that transform eq. (2.16) from
@@ -114,6 +115,8 @@ class RKIDPSolver : public IDPODESolver
 public:
    RKIDPSolver(int s_, const real_t a_[], const real_t b_[], const real_t c_[]);
    ~RKIDPSolver();
+
+   void UseMask(bool mask_on) { use_masks = mask_on; }
 
    void Init(LimitedTimeDependentOperator &f) override;
    void Step(Vector &x, double &t, double &dt) override;

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -52,6 +52,10 @@ public:
    /// Perform the unlimited action of the operator
    virtual void MultUnlimited(const Vector &u, Vector &k) const = 0;
 
+   /// Compute mask of the state for the update
+   virtual void ComputeMask(const Vector &u, Array<bool> &mask) const
+   { MFEM_ABORT("Mask computation not implemented!"); }
+
    /// Limit the action vector @a k
    virtual void LimitMult(const Vector &u, Vector &k) const = 0;
 };
@@ -61,6 +65,12 @@ class IDPODESolver : public ODESolver
 protected:
    /// Pointer to the associated LimitedTimeDependentOperator.
    LimitedTimeDependentOperator *f;  // f(.,t) : R^n --> R^n
+
+   void AddMasked(const Array<bool> &mask, real_t a, const Vector &va, real_t b,
+                  const Vector &vb, Vector &vc);
+
+   void UpdateMask(const Vector &x, const Vector &dx, real_t dt,
+                   Array<bool> &mask);
 
    void Init(TimeDependentOperator &f_) override
    { MFEM_ABORT("Limited time-dependent operator must be assigned!"); }
@@ -83,6 +93,7 @@ public:
 class RK2IDPSolver : public IDPODESolver
 {
    Vector dx12, dx;
+   Array<bool> mask;
 
 public:
    void Init(LimitedTimeDependentOperator &f) override;

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2024, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+
+#ifndef MFEM_REMHOS_SOLVERS
+#define MFEM_REMHOS_SOLVERS
+
+#include "mfem.hpp"
+
+namespace mfem
+{
+
+class RK2IDPSolver : public ODESolver
+{
+   Vector dx12, dx;
+
+public:
+   RK2IDPSolver();
+   void Init(TimeDependentOperator &f) override;
+   void Step(Vector &x, double &t, double &dt) override;
+};
+
+} // namespace mfem
+
+#endif // MFEM_REMHOS_SOLVERS

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -72,12 +72,19 @@ public:
    { ODESolver::Init(f_); f = &f_; }
 };
 
+class ForwardEulerIDPSolver : public IDPODESolver
+{
+   Vector dx;
+public:
+   void Init(LimitedTimeDependentOperator &f) override;
+   void Step(Vector &x, double &t, double &dt) override;
+};
+
 class RK2IDPSolver : public IDPODESolver
 {
    Vector dx12, dx;
 
 public:
-   RK2IDPSolver();
    void Init(LimitedTimeDependentOperator &f) override;
    void Step(Vector &x, double &t, double &dt) override;
 };

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -115,6 +115,20 @@ public:
    RK2IDPSolver() : RKIDPSolver(2, a, b, c) { }
 };
 
+class RK3IDPSolver : public RKIDPSolver
+{
+   static const real_t a[], b[], c[];
+public:
+   RK3IDPSolver() : RKIDPSolver(3, a, b, c) { }
+};
+
+class RK4IDPSolver : public RKIDPSolver
+{
+   static const real_t a[], b[], c[];
+public:
+   RK4IDPSolver() : RKIDPSolver(4, a, b, c) { }
+};
+
 } // namespace mfem
 
 #endif // MFEM_REMHOS_SOLVERS

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -40,7 +40,7 @@ public:
 
    virtual ~LimitedTimeDependentOperator() { }
 
-   virtual void SetDt(double dt_) { dt = dt_; }
+   virtual void SetDt(real_t dt_) { dt = dt_; }
    virtual real_t GetDt() const { return dt; }
 
    void Mult(const Vector &u, Vector &k) const override

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -57,6 +57,8 @@ public:
    { MFEM_ABORT("Mask computation not implemented!"); }
 
    /// Limit the action vector @a k
+   /// Assumes that MultUnlimited(u, k) has been called, which has computed the
+   /// unlimited solution in @a k.
    virtual void LimitMult(const Vector &u, Vector &k) const = 0;
 };
 
@@ -94,6 +96,7 @@ class RKIDPSolver : public IDPODESolver
 
    void ConstructD();
 
+   /// Adds only DOFs that have mask = true.
    void AddMasked(const Array<bool> &mask, real_t b,
                   const Vector &vb, Vector &va);
 

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -129,6 +129,13 @@ public:
    RK4IDPSolver() : RKIDPSolver(4, a, b, c) { }
 };
 
+class RK6IDPSolver : public RKIDPSolver
+{
+   static const real_t a[], b[], c[];
+public:
+   RK6IDPSolver() : RKIDPSolver(6, a, b, c) { }
+};
+
 } // namespace mfem
 
 #endif // MFEM_REMHOS_SOLVERS

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -66,12 +66,6 @@ protected:
    /// Pointer to the associated LimitedTimeDependentOperator.
    LimitedTimeDependentOperator *f;  // f(.,t) : R^n --> R^n
 
-   void AddMasked(const Array<bool> &mask, real_t a, const Vector &va, real_t b,
-                  const Vector &vb, Vector &vc);
-
-   void UpdateMask(const Vector &x, const Vector &dx, real_t dt,
-                   Array<bool> &mask);
-
    void Init(TimeDependentOperator &f_) override
    { MFEM_ABORT("Limited time-dependent operator must be assigned!"); }
 public:
@@ -90,14 +84,35 @@ public:
    void Step(Vector &x, double &t, double &dt) override;
 };
 
-class RK2IDPSolver : public IDPODESolver
+class RKIDPSolver : public IDPODESolver
 {
-   Vector dx12, dx;
+   const int s;
+   const real_t *a, *b, *c;
+   real_t *d;
+   Vector *dxs;
    Array<bool> mask;
 
+   void ConstructD();
+
+   void AddMasked(const Array<bool> &mask, real_t b,
+                  const Vector &vb, Vector &va);
+
+   void UpdateMask(const Vector &x, const Vector &dx, real_t dt,
+                   Array<bool> &mask);
+
 public:
+   RKIDPSolver(int s_, const real_t a_[], const real_t b_[], const real_t c_[]);
+   ~RKIDPSolver();
+
    void Init(LimitedTimeDependentOperator &f) override;
    void Step(Vector &x, double &t, double &dt) override;
+};
+
+class RK2IDPSolver : public RKIDPSolver
+{
+   static const real_t a[], b[], c[];
+public:
+   RK2IDPSolver() : RKIDPSolver(2, a, b, c) { }
 };
 
 } // namespace mfem

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -24,6 +24,9 @@ namespace mfem
 
 class LimitedTimeDependentOperator : public TimeDependentOperator
 {
+protected:
+   real_t dt;
+
 public:
    /** @brief Construct a "square" LimitedTimeDependentOperator (u,t) -> k(u,t),
       where u and k have the same dimension @a n. */
@@ -36,6 +39,9 @@ public:
       : TimeDependentOperator(h, w, t) { }
 
    virtual ~LimitedTimeDependentOperator() { }
+
+   virtual void SetDt(double dt_) { dt = dt_; }
+   virtual real_t GetDt() const { return dt; }
 
    void Mult(const Vector &u, Vector &k) const override
    {

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -69,7 +69,12 @@ protected:
    LimitedTimeDependentOperator *f;  // f(.,t) : R^n --> R^n
 
    void Init(TimeDependentOperator &f_) override
-   { MFEM_ABORT("Limited time-dependent operator must be assigned!"); }
+   {
+      auto lo = dynamic_cast<LimitedTimeDependentOperator *>(&f_);
+      if (lo) { Init(*lo); }
+      else    { MFEM_ABORT("LimitedTimeDependentOperator must be assigned!"); }
+   }
+
 public:
    IDPODESolver() : ODESolver(), f(NULL) { }
    virtual ~IDPODESolver() { }
@@ -94,6 +99,9 @@ class RKIDPSolver : public IDPODESolver
    Vector *dxs;
    Array<bool> mask;
 
+   // This function constructs coefficients that transform eq. (2.16) from
+   // JLG's paper to an update that only uses the previous limited updates.
+   // This function does not depend on the Operator f in any way.
    void ConstructD();
 
    /// Adds only DOFs that have mask = true.

--- a/remhos_sync.cpp
+++ b/remhos_sync.cpp
@@ -116,6 +116,9 @@ void ZeroOutEmptyDofs(const Array<bool> &ind_elem,
 void ComputeMinMaxS(int NE, const Vector &us, const Vector &u,
                     double &s_min_glob, double &s_max_glob)
 {
+   u.HostRead();
+   us.HostRead();
+
    const int size = u.Size();
    Vector s(size);
    Array<bool> bool_el, bool_dofs;


### PR DESCRIPTION
This PR adds invariant domain preserving (IDP) time integrators based on explicit Runge-Kutta (ERK) methods. The implementation is general, where `RKIDPSolver` class converts any ERK scheme with non-decreasing time levels to the IDP form following the methodology of [Alexandre Ern and Jean-Luc Guermond, Invariant-Domain-Preserving High-Order Time Stepping: I. Explicit Runge--Kutta Schemes, SIAM Journal on Scientific Computing, 44:5, A3366-A3392, 2022](https://epubs.siam.org/doi/abs/10.1137/21M145793X). The idea is that updates between consecutive stages are performed instead of a linear combination of the states, which enables sequential limiting for each new stage. Due to this kind of sub-stepping, the CFL criterion is also relaxed to these stage differences.

