### PR TITLE
Change mfem include header name

### DIFF
--- a/remhos.cpp
+++ b/remhos.cpp
@@ -39,7 +39,7 @@
 #include "remhos_tools.hpp"
 #include "remhos_sync.hpp"
 #include "fem/qinterp/eval.hpp"
-#include "fem/qinterp/det.cpp"
+#include "fem/qinterp/det.hpp"
 #include "fem/qinterp/grad.hpp"
 #include "fem/integ/bilininteg_mass_kernels.hpp"
 


### PR DESCRIPTION
This PR changes the include header name from `fem/qinterp/det.cpp` to `fem/qinterp/det.hpp`
This change depends on a corresponding change to the mfem source (https://github.com/mfem/mfem/pull/4866)