### PR TITLE
build fixes for nvcc

### DIFF
--- a/remhos.cpp
+++ b/remhos.cpp
@@ -1296,8 +1296,8 @@ AdvectionOperator::AdvectionOperator(const Array<int> &offsets,
    ho_solver(hos), lo_solver(los), fct_solver(fct), mono_solver(mos) { }
 
 void check_violation(const Vector &u_new,
-    const Vector &u_min, const Vector &u_max,
-    string info, double tol, const Array<bool> *active_dofs)
+                     const Vector &u_min, const Vector &u_max,
+                     string info, double tol, const Array<bool> *active_dofs)
 {
    const int size = u_new.Size();
    for (int i = 0; i < size; i++)
@@ -1315,8 +1315,8 @@ void check_violation(const Vector &u_new,
 }
 
 void check_violation(const Vector &u, double dt, const Vector &du_new,
-    const Vector &u_min, const Vector &u_max,
-    string info, double tol, const Array<bool> *active_dofs)
+                     const Vector &u_min, const Vector &u_max,
+                     string info, double tol, const Array<bool> *active_dofs)
 {
    const int size = u.Size();
    for (int i = 0; i < size; i++)

--- a/remhos_solvers.hpp
+++ b/remhos_solvers.hpp
@@ -105,10 +105,6 @@ class RKIDPSolver : public IDPODESolver
    // This function does not depend on the Operator f in any way.
    void ConstructD();
 
-   /// Adds only DOFs that have mask = true.
-   void AddMasked(const Array<bool> &mask, real_t b,
-                  const Vector &vb, Vector &va);
-
    void UpdateMask(const Vector &x, const Vector &dx, real_t dt,
                    Array<bool> &mask);
 
@@ -117,6 +113,11 @@ public:
    ~RKIDPSolver();
 
    void UseMask(bool mask_on) { use_masks = mask_on; }
+
+   /// Adds only DOFs that have mask = true.
+   /// Must be public due to NVCC
+   void AddMasked(const Array<bool> &mask, real_t b,
+                  const Vector &vb, Vector &va);
 
    void Init(LimitedTimeDependentOperator &f) override;
    void Step(Vector &x, double &t, double &dt) override;


### PR DESCRIPTION
Functions which have a device lambda must be public when using NVCC