### PR TITLE
shared umpire device pool and mfem GPU-aware MPI

### DIFF
--- a/remhos.cpp
+++ b/remhos.cpp
@@ -47,6 +47,7 @@
 #define REMHOS_USE_DEVICE_UMPIRE
 #include <umpire/Umpire.hpp>
 #include <umpire/strategy/QuickPool.hpp>
+#endif
 
 #ifdef USE_CALIPER
 #include <caliper/cali.h>

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -209,6 +209,7 @@ MFEM_EXPORT int remhos(int argc, char *argv[], double &final_mass_u)
    int vis_steps = 100;
    const char *device_config = "cpu";
    bool gpu_aware_mpi = false;
+   int dev_pool_size = 4;
 
    int precision = 8;
    cout.precision(precision);
@@ -296,6 +297,8 @@ MFEM_EXPORT int remhos(int argc, char *argv[], double &final_mass_u)
                   "Enable remap of synchronized product fields.");
    args.AddOption(&vis_steps, "-vs", "--visualization-steps",
                   "Visualize every n-th timestep.");
+   args.AddOption(&dev_pool_size, "-pool", "--dev-pool-size",
+                  "Size (in GB) for the umpire device pool");
    args.Parse();
    if (!args.Good())
    {
@@ -307,7 +310,9 @@ MFEM_EXPORT int remhos(int argc, char *argv[], double &final_mass_u)
 #ifdef REMHOS_USE_DEVICE_UMPIRE
    auto &rm = umpire::ResourceManager::getInstance();
    const char * allocator_name = "remhos_device_alloc";
-   rm.makeAllocator<umpire::strategy::QuickPool>(allocator_name, rm.getAllocator("DEVICE"));
+   size_t umpire_dev_pool_size = ((size_t) dev_pool_size) * 1024 * 1024 * 1024;
+   size_t umpire_dev_block_size = 1024 * 1024;
+   rm.makeAllocator<umpire::strategy::QuickPool>(allocator_name, rm.getAllocator("DEVICE"), umpire_dev_pool_size, umpire_dev_block_size);
 
 #ifdef HYPRE_USING_UMPIRE
    HYPRE_SetUmpireDevicePoolName(allocator_name);

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -347,8 +347,8 @@ MFEM_EXPORT int remhos(int argc, char *argv[], double &final_mass_u)
    // Enable hardware devices such as GPUs, and programming models such as
    // CUDA, OCCA, RAJA and OpenMP based on command line options.
    Device device(device_config);
-   if (myid == 0) { device.Print(); }
    device.SetGPUAwareMPI(gpu_aware_mpi);
+   if (myid == 0) { device.Print(); }
 
    if (myid == 0) { KernelReporter::Enable(); }
    using TENS = QuadratureInterpolator::TensorEvalKernels;

--- a/remhos.cpp
+++ b/remhos.cpp
@@ -207,6 +207,7 @@ MFEM_EXPORT int remhos(int argc, char *argv[], double &final_mass_u)
    bool product_sync = false;
    int vis_steps = 100;
    const char *device_config = "cpu";
+   bool gpu_aware_mpi = false;
 
    int precision = 8;
    cout.precision(precision);
@@ -262,6 +263,8 @@ MFEM_EXPORT int remhos(int argc, char *argv[], double &final_mass_u)
                   "Enable or disable next gen full assembly for the HO solution.");
    args.AddOption(&device_config, "-d", "--device",
                   "Device configuration string, see Device::Configure().");
+   args.AddOption(&gpu_aware_mpi, "-gam", "--gpu-aware-mpi", "-no-gam",
+                  "--no-gpu-aware-mpi", "Enable GPU aware MPI communications.");
    args.AddOption(&smth_ind_type, "-si", "--smth_ind",
                   "Smoothness indicator: 0 - no smoothness indicator,\n\t"
                   "                      1 - approx_quadratic,\n\t"


### PR DESCRIPTION
This PR:
1. Ceates a single device umpire pool for hypre and mfem (the pool setup code is borrowed from laghos https://github.com/CEED/Laghos/pull/198)
2. Adds an input option to specify the device pool size
3. Adds an option to support GPU-aware MPI in remhos